### PR TITLE
Improve Testing in PR

### DIFF
--- a/.lighthouse/jenkins-x/peacock/release.yaml
+++ b/.lighthouse/jenkins-x/peacock/release.yaml
@@ -27,7 +27,7 @@ spec:
               name: peacock-run
               resources: {}
               script: |
-                #!/usr/bin/env sh
+                #!/usr/bin/env bash
                 source .jx/variables.sh
                 make install
                 peacock run

--- a/.lighthouse/jenkins-x/peacock/release.yaml
+++ b/.lighthouse/jenkins-x/peacock/release.yaml
@@ -22,12 +22,13 @@ spec:
                 jx gitops variables --commit=false
                 echo "export SLACK_TOKEN=\"$(kubectl get secret peacock-slack -n jx-staging -o jsonpath="{.data['token']}" | base64 -d)\"" >> .jx/variables.sh
               workingDir: /workspace/source
-            - image: ghcr.io/spring-financial-group/peacock:latest
+            - image: golang:1.18
               name: peacock-run
               resources: {}
               script: |
                 #!/usr/bin/env sh
                 source .jx/variables.sh
+                make install
                 peacock run
               workingDir: /workspace/source
   podTemplate: {}

--- a/.lighthouse/jenkins-x/peacock/release.yaml
+++ b/.lighthouse/jenkins-x/peacock/release.yaml
@@ -20,6 +20,7 @@ spec:
               script: |
                 #!/usr/bin/env sh
                 jx gitops variables --commit=false
+                echo "export GITHUB_TOKEN=\"$(kubectl get secret github-config -n jx-staging -o jsonpath="{.data['github-token']}" | base64 -d)\"" >> .jx/variables.sh
                 echo "export SLACK_TOKEN=\"$(kubectl get secret peacock-slack -n jx-staging -o jsonpath="{.data['token']}" | base64 -d)\"" >> .jx/variables.sh
               workingDir: /workspace/source
             - image: golang:1.18

--- a/.lighthouse/jenkins-x/peacock/verify.yaml
+++ b/.lighthouse/jenkins-x/peacock/verify.yaml
@@ -20,6 +20,7 @@ spec:
               script: |
                 #!/usr/bin/env sh
                 jx gitops variables --commit=false
+                echo "export GITHUB_TOKEN=\"$(kubectl get secret github-config -n jx-staging -o jsonpath="{.data['github-token']}" | base64 -d)\"" >> .jx/variables.sh
                 echo "export SLACK_TOKEN=\"$(kubectl get secret peacock-slack -n jx-staging -o jsonpath="{.data['token']}" | base64 -d)\"" >> .jx/variables.sh
               workingDir: /workspace/source
             - image: golang:1.18
@@ -29,7 +30,7 @@ spec:
                 #!/usr/bin/env sh
                 source .jx/variables.sh
                 make install
-                peacock run --dry-run --comment-validation --git-token-key="GIT_TOKEN"
+                peacock run --dry-run --comment-validation
               workingDir: /workspace/source
   podTemplate: {}
   serviceAccountName: tekton-bot

--- a/.lighthouse/jenkins-x/peacock/verify.yaml
+++ b/.lighthouse/jenkins-x/peacock/verify.yaml
@@ -27,7 +27,7 @@ spec:
               name: peacock-run
               resources: {}
               script: |
-                #!/usr/bin/env sh
+                #!/usr/bin/env bash
                 source .jx/variables.sh
                 make install
                 peacock run --dry-run --comment-validation

--- a/.lighthouse/jenkins-x/peacock/verify.yaml
+++ b/.lighthouse/jenkins-x/peacock/verify.yaml
@@ -22,13 +22,14 @@ spec:
                 jx gitops variables --commit=false
                 echo "export SLACK_TOKEN=\"$(kubectl get secret peacock-slack -n jx-staging -o jsonpath="{.data['token']}" | base64 -d)\"" >> .jx/variables.sh
               workingDir: /workspace/source
-            - image: ghcr.io/spring-financial-group/peacock:latest
+            - image: golang:1.18
               name: peacock-run
               resources: {}
               script: |
                 #!/usr/bin/env sh
                 source .jx/variables.sh
-                peacock run --dry-run --comment-validation
+                make install
+                peacock run --dry-run --comment-validation --git-token-key="GIT_TOKEN"
               workingDir: /workspace/source
   podTemplate: {}
   serviceAccountName: tekton-bot

--- a/pkg/cmd/run/run.go
+++ b/pkg/cmd/run/run.go
@@ -330,8 +330,11 @@ func (o *Options) PostErrorToPR(ctx context.Context, err error) {
 // and sets up the required clients
 func (o *Options) initialiseFlagsAndClients() (err error) {
 	// validate flags
+	if o.GitHubToken == "" {
+		return errors.New("github token is required")
+	}
 	if o.DryRun && o.PRNumber == -1 {
-		return errors.New("pr-number required")
+		return errors.New("pr-number is required")
 	}
 	if o.GitServerURL == "" {
 		o.GitServerURL = domain.GitHubURL


### PR DESCRIPTION
Looks like GITHUB_TOKEN isn't actually passed in the pipelines, think jx-helpers was actually pulling it from the credentials file or something. Will look into supporting this, but for the time being I'll just add the token as an env var. 

* Installing Peacock from make in PR to test latest version
* Throwing an error if Github token isn't passed