### PR TITLE
feat: check whether the messages have changed since the last run

### DIFF
--- a/pkg/cmd/run/run.go
+++ b/pkg/cmd/run/run.go
@@ -193,7 +193,7 @@ func (o *Options) Run() error {
 	}
 
 	if o.DryRun {
-		log.Info("Posting message breakdown to pull request")
+		log.Info("Generating message breakdown")
 		breakdown, err := o.GetMessageBreakdown(ctx, messages)
 		if err != nil {
 			err = errors.Wrapf(err, "failed to generate breakdown of messages")
@@ -333,11 +333,11 @@ func (o *Options) HaveMessagesChanged(ctx context.Context, messages []message.Me
 
 	var previousHash string
 	for _, c := range comments {
-		// GitHub returns the comments sorted by most recent first, so the first matching comment
+		// Comments sorted by most recent first, so the first matching comment
 		// was the last one posted by the bot
 		previousHash = o.getHashFromComment(*c.Body)
 		if previousHash != "" {
-			log.Info("Found previous previous hash in comment")
+			log.Info("Found previous hash in comment")
 			break
 		}
 	}

--- a/pkg/cmd/run/run.go
+++ b/pkg/cmd/run/run.go
@@ -3,6 +3,9 @@ package run
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -19,6 +22,7 @@ import (
 	"github.com/spring-financial-group/peacock/pkg/utils"
 	"github.com/spring-financial-group/peacock/pkg/utils/templates"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 	"text/template"
@@ -190,15 +194,14 @@ func (o *Options) Run() error {
 
 	if o.DryRun {
 		log.Info("Posting message breakdown to pull request")
-		breakdown, err := o.GenerateMessageBreakdown(messages)
+		breakdown, err := o.GetMessageBreakdown(ctx, messages)
 		if err != nil {
 			err = errors.Wrapf(err, "failed to generate breakdown of messages")
 			o.PostErrorToPR(ctx, err)
 			return err
 		}
-		log.Info(breakdown)
 		// Return before sending messages
-		if o.CommentValidation {
+		if o.CommentValidation && breakdown != "" {
 			if err := o.GitServerClient.CommentOnPR(ctx, o.PRNumber, breakdown); err != nil {
 				return err
 			}
@@ -298,8 +301,70 @@ func (o *Options) ValidateMessagesWithConfig(messages []message.Message) error {
 	return nil
 }
 
-// GenerateMessageBreakdown creates a breakdown of the messages found in the pr description
-func (o *Options) GenerateMessageBreakdown(messages []message.Message) (string, error) {
+// GetMessageBreakdown creates a breakdown of the messages found in the pr description if the messages have changed
+// since the last run
+func (o *Options) GetMessageBreakdown(ctx context.Context, messages []message.Message) (string, error) {
+	changed, hash, err := o.HaveMessagesChanged(ctx, messages)
+	if err != nil {
+		return "", err
+	}
+	if !changed {
+		return "", nil
+	}
+	return o.generateBreakdown(messages, hash)
+}
+
+// HaveMessagesChanged checks if the messages have changed since the last time the breakdown was posted to the PR
+func (o *Options) HaveMessagesChanged(ctx context.Context, messages []message.Message) (bool, string, error) {
+	log.Info("Checking if messages have changed")
+	currentHash, err := o.generateMessageHash(messages)
+	if err != nil {
+		return false, "", err
+	}
+
+	comments, err := o.GitServerClient.GetPRComments(ctx, o.PRNumber)
+	if err != nil {
+		return false, "", err
+	}
+	if len(comments) < 1 {
+		log.Info("No comments found on PR")
+		return true, currentHash, nil
+	}
+
+	var previousHash string
+	for _, c := range comments {
+		// GitHub returns the comments sorted by most recent first, so the first matching comment
+		// was the last one posted by the bot
+		previousHash = o.getHashFromComment(*c.Body)
+		if previousHash != "" {
+			log.Info("Found previous previous hash in comment")
+			break
+		}
+	}
+
+	if previousHash == "" {
+		log.Info("No previous hash found in comments")
+		return true, currentHash, nil
+	}
+
+	if previousHash == currentHash {
+		log.Info("Previous hash matches current hash, messages have not changed")
+		return false, "", nil
+	}
+	log.Info("Previous hash does not match current hash, messages have changed")
+	return true, currentHash, nil
+}
+
+func (o *Options) getHashFromComment(comment string) string {
+	re := regexp.MustCompile(`(?m)<!-- hash: ([a-zA-Z0-9]+) -->`)
+	matches := re.FindStringSubmatch(comment)
+	if len(matches) != 2 {
+		return ""
+	}
+	return matches[1]
+}
+
+func (o *Options) generateBreakdown(messages []message.Message, hash string) (string, error) {
 	breakdownTmpl := `[Peacock] Successfully validated {{ len .messages }} message(s).
 {{ range $idx, $val := .messages }}
 ***
@@ -311,7 +376,8 @@ Message {{ inc $idx }} will be sent to: {{ commaSep $val.TeamNames }}
 
 </details>
 
-{{ end }}`
+{{ end -}}
+<!-- hash: {{ .hash }} -->`
 
 	tmplFuncs := template.FuncMap{
 		"inc":      func(i int) int { return i + 1 },
@@ -327,11 +393,22 @@ Message {{ inc $idx }} will be sent to: {{ commaSep $val.TeamNames }}
 	err = tpl.Execute(&buf, map[string]any{
 		"totalTeams": len(o.Config.GetAllTeamNames()),
 		"messages":   messages,
+		"hash":       hash,
 	})
 	if err != nil {
 		return "", err
 	}
 	return strings.TrimSpace(buf.String()), nil
+}
+
+func (o *Options) generateMessageHash(messages []message.Message) (string, error) {
+	data, err := json.Marshal(messages)
+	if err != nil {
+		return "", err
+	}
+	h := sha256.New()
+	h.Write(data)
+	return hex.EncodeToString(h.Sum(nil)), nil
 }
 
 // PostErrorToPR posts an error to the pull request as a comment

--- a/pkg/cmd/run/run_test.go
+++ b/pkg/cmd/run/run_test.go
@@ -22,7 +22,7 @@ func TestOptions_HaveMessagesChanged(t *testing.T) {
 	testCases := []struct {
 		name             string
 		inputMessages    []message.Message
-		returnedComments []*github.PullRequestComment
+		returnedComments []*github.IssueComment
 		expectedHash     string
 		expectedChanged  bool
 	}{
@@ -33,7 +33,7 @@ func TestOptions_HaveMessagesChanged(t *testing.T) {
 					Content: "New release of some infrastructure\nrelated things",
 				},
 			},
-			returnedComments: []*github.PullRequestComment{
+			returnedComments: []*github.IssueComment{
 				{
 					Body: utils.NewPtr("<!-- hash: d88cd4f055916a0a0cda7d44644750bf6008db30bbfc4ed8ee1dc8888aa817d9 -->"),
 				},
@@ -48,7 +48,7 @@ func TestOptions_HaveMessagesChanged(t *testing.T) {
 					Content: "New release of some infrastructure\nrelated things",
 				},
 			},
-			returnedComments: []*github.PullRequestComment{
+			returnedComments: []*github.IssueComment{
 				{
 					Body: utils.NewPtr("<!-- hash: SomeOtherHash -->"),
 				},
@@ -63,7 +63,7 @@ func TestOptions_HaveMessagesChanged(t *testing.T) {
 					Content: "New release of some infrastructure\nrelated things",
 				},
 			},
-			returnedComments: []*github.PullRequestComment{
+			returnedComments: []*github.IssueComment{
 				{
 					Body: utils.NewPtr("<!-- hash: SomeOtherHash -->"),
 				},
@@ -87,7 +87,7 @@ func TestOptions_HaveMessagesChanged(t *testing.T) {
 					Content: "New release of some infrastructure\nrelated things",
 				},
 			},
-			returnedComments: []*github.PullRequestComment{
+			returnedComments: []*github.IssueComment{
 				{
 					Body: utils.NewPtr("<!-- hash: d88cd4f055916a0a0cda7d44644750bf6008db30bbfc4ed8ee1dc8888aa817d9 -->"),
 				},
@@ -111,7 +111,7 @@ func TestOptions_HaveMessagesChanged(t *testing.T) {
 					Content: "New release of some infrastructure\nrelated things",
 				},
 			},
-			returnedComments: []*github.PullRequestComment{
+			returnedComments: []*github.IssueComment{
 				{
 					Body: utils.NewPtr("<!-- hash: AnotherHash -->"),
 				},
@@ -135,7 +135,7 @@ func TestOptions_HaveMessagesChanged(t *testing.T) {
 					Content: "New release of some infrastructure\nrelated things",
 				},
 			},
-			returnedComments: []*github.PullRequestComment{
+			returnedComments: []*github.IssueComment{
 				{
 					Body: utils.NewPtr("Comment from someone else"),
 				},

--- a/pkg/cmd/run/run_test.go
+++ b/pkg/cmd/run/run_test.go
@@ -1,7 +1,9 @@
 package run_test
 
 import (
+	"context"
 	"fmt"
+	"github.com/google/go-github/v47/github"
 	"github.com/spring-financial-group/peacock/pkg/cmd/run"
 	"github.com/spring-financial-group/peacock/pkg/domain"
 	"github.com/spring-financial-group/peacock/pkg/domain/mocks"
@@ -13,6 +15,157 @@ import (
 	"github.com/stretchr/testify/mock"
 	"testing"
 )
+
+func TestOptions_HaveMessagesChanged(t *testing.T) {
+	mockGitServer := mocks.NewGitServer(t)
+	// Comments returned from the GitHub API are sorted by most recent first
+	testCases := []struct {
+		name             string
+		inputMessages    []message.Message
+		returnedComments []*github.PullRequestComment
+		expectedHash     string
+		expectedChanged  bool
+	}{
+		{
+			name: "OneCommentSameHash",
+			inputMessages: []message.Message{
+				{
+					Content: "New release of some infrastructure\nrelated things",
+				},
+			},
+			returnedComments: []*github.PullRequestComment{
+				{
+					Body: utils.NewPtr("<!-- hash: d88cd4f055916a0a0cda7d44644750bf6008db30bbfc4ed8ee1dc8888aa817d9 -->"),
+				},
+			},
+			expectedHash:    "",
+			expectedChanged: false,
+		},
+		{
+			name: "OneCommentDifferentHash",
+			inputMessages: []message.Message{
+				{
+					Content: "New release of some infrastructure\nrelated things",
+				},
+			},
+			returnedComments: []*github.PullRequestComment{
+				{
+					Body: utils.NewPtr("<!-- hash: SomeOtherHash -->"),
+				},
+			},
+			expectedHash:    "d88cd4f055916a0a0cda7d44644750bf6008db30bbfc4ed8ee1dc8888aa817d9",
+			expectedChanged: true,
+		},
+		{
+			name: "MultipleCommentsDifferentHashes",
+			inputMessages: []message.Message{
+				{
+					Content: "New release of some infrastructure\nrelated things",
+				},
+			},
+			returnedComments: []*github.PullRequestComment{
+				{
+					Body: utils.NewPtr("<!-- hash: SomeOtherHash -->"),
+				},
+				{
+					Body: utils.NewPtr("<!-- hash: AnotherHash -->"),
+				},
+				{
+					Body: utils.NewPtr("<!-- hash: HashingHel -->"),
+				},
+				{
+					Body: utils.NewPtr("<!-- hash: AllTheHashes -->"),
+				},
+			},
+			expectedHash:    "d88cd4f055916a0a0cda7d44644750bf6008db30bbfc4ed8ee1dc8888aa817d9",
+			expectedChanged: true,
+		},
+		{
+			name: "MostRecentCommentSameHash",
+			inputMessages: []message.Message{
+				{
+					Content: "New release of some infrastructure\nrelated things",
+				},
+			},
+			returnedComments: []*github.PullRequestComment{
+				{
+					Body: utils.NewPtr("<!-- hash: d88cd4f055916a0a0cda7d44644750bf6008db30bbfc4ed8ee1dc8888aa817d9 -->"),
+				},
+				{
+					Body: utils.NewPtr("<!-- hash: AnotherHash -->"),
+				},
+				{
+					Body: utils.NewPtr("<!-- hash: HashingHel -->"),
+				},
+				{
+					Body: utils.NewPtr("<!-- hash: AllTheHashes -->"),
+				},
+			},
+			expectedHash:    "",
+			expectedChanged: false,
+		},
+		{
+			name: "MostRecentCommentDifferentHash",
+			inputMessages: []message.Message{
+				{
+					Content: "New release of some infrastructure\nrelated things",
+				},
+			},
+			returnedComments: []*github.PullRequestComment{
+				{
+					Body: utils.NewPtr("<!-- hash: AnotherHash -->"),
+				},
+				{
+					Body: utils.NewPtr("<!-- hash: d88cd4f055916a0a0cda7d44644750bf6008db30bbfc4ed8ee1dc8888aa817d9 -->"),
+				},
+				{
+					Body: utils.NewPtr("<!-- hash: HashingHel -->"),
+				},
+				{
+					Body: utils.NewPtr("<!-- hash: AllTheHashes -->"),
+				},
+			},
+			expectedHash:    "d88cd4f055916a0a0cda7d44644750bf6008db30bbfc4ed8ee1dc8888aa817d9",
+			expectedChanged: true,
+		},
+		{
+			name: "NoCommentsContainingMetadata",
+			inputMessages: []message.Message{
+				{
+					Content: "New release of some infrastructure\nrelated things",
+				},
+			},
+			returnedComments: []*github.PullRequestComment{
+				{
+					Body: utils.NewPtr("Comment from someone else"),
+				},
+				{
+					Body: utils.NewPtr("Comment from someone else"),
+				},
+				{
+					Body: utils.NewPtr("Really different comment"),
+				},
+			},
+			expectedHash:    "d88cd4f055916a0a0cda7d44644750bf6008db30bbfc4ed8ee1dc8888aa817d9",
+			expectedChanged: true,
+		},
+	}
+
+	opts := &run.Options{
+		GitServerClient: mockGitServer,
+	}
+
+	for _, tt := range testCases {
+		mockGitServer.On("GetPRComments", mock.AnythingOfType("*context.emptyCtx"), opts.PRNumber).Return(tt.returnedComments, nil).Once()
+
+		t.Run(tt.name, func(t *testing.T) {
+			actualChanged, actualHash, err := opts.HaveMessagesChanged(context.Background(), tt.inputMessages)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedChanged, actualChanged)
+			assert.Equal(t, tt.expectedHash, actualHash)
+		})
+	}
+}
 
 func TestOptions_Run(t *testing.T) {
 	mockGitServer := mocks.NewGitServer(t)
@@ -83,6 +236,7 @@ func TestOptions_Run(t *testing.T) {
 		if tt.opts.DryRun {
 			mockGitServer.On("GetPullRequestBodyFromPRNumber", mock.AnythingOfType("*context.emptyCtx"), tt.opts.PRNumber).Return(tt.prBody, nil).Once()
 			mockGitServer.On("CommentOnPR", mock.AnythingOfType("*context.emptyCtx"), tt.opts.PRNumber, mock.AnythingOfType("string")).Return(nil).Once()
+			mockGitServer.On("GetPRComments", mock.AnythingOfType("*context.emptyCtx"), tt.opts.PRNumber).Return(nil, nil)
 		} else {
 			mockGitClient.On("GetLatestCommitSHA").Return("SHA", nil)
 			mockGitServer.On("GetPullRequestBodyFromCommit", mock.AnythingOfType("*context.emptyCtx"), "SHA").Return(tt.prBody, nil).Once()
@@ -107,6 +261,8 @@ func TestOptions_Run(t *testing.T) {
 }
 
 func TestOptions_GenerateMessageBreakdown(t *testing.T) {
+	mockGitServer := mocks.NewGitServer(t)
+
 	testCases := []struct {
 		name              string
 		opts              *run.Options
@@ -116,6 +272,7 @@ func TestOptions_GenerateMessageBreakdown(t *testing.T) {
 		{
 			name: "OneMessage",
 			opts: &run.Options{
+				GitServerClient: mockGitServer,
 				Config: &feathers.Feathers{
 					Teams: []feathers.Team{
 						{Name: "infrastructure"},
@@ -128,11 +285,12 @@ func TestOptions_GenerateMessageBreakdown(t *testing.T) {
 					Content:   "New release of some infrastructure\nrelated things",
 				},
 			},
-			expectedBreakdown: "[Peacock] Successfully validated 1 message(s).\n\n***\nMessage 1 will be sent to: infrastructure\n<details>\n<summary>Message Breakdown</summary>\n\nNew release of some infrastructure\nrelated things\n\n</details>",
+			expectedBreakdown: "[Peacock] Successfully validated 1 message(s).\n\n***\nMessage 1 will be sent to: infrastructure\n<details>\n<summary>Message Breakdown</summary>\n\nNew release of some infrastructure\nrelated things\n\n</details>\n\n<!-- hash: 89d156a04847b48a4e68948b83256740662f2212236fb88fa304fb28d6d6d0f6 -->",
 		},
 		{
 			name: "MultipleMessages&MultipleTeams",
 			opts: &run.Options{
+				GitServerClient: mockGitServer,
 				Config: &feathers.Feathers{
 					Teams: []feathers.Team{
 						{Name: "infrastructure"},
@@ -150,13 +308,16 @@ func TestOptions_GenerateMessageBreakdown(t *testing.T) {
 					Content:   "New release of some ml\nrelated things",
 				},
 			},
-			expectedBreakdown: "[Peacock] Successfully validated 2 message(s).\n\n***\nMessage 1 will be sent to: infrastructure\n<details>\n<summary>Message Breakdown</summary>\n\nNew release of some infrastructure\nrelated things\n\n</details>\n\n\n***\nMessage 2 will be sent to: ml\n<details>\n<summary>Message Breakdown</summary>\n\nNew release of some ml\nrelated things\n\n</details>",
+			expectedBreakdown: "[Peacock] Successfully validated 2 message(s).\n\n***\nMessage 1 will be sent to: infrastructure\n<details>\n<summary>Message Breakdown</summary>\n\nNew release of some infrastructure\nrelated things\n\n</details>\n\n\n***\nMessage 2 will be sent to: ml\n<details>\n<summary>Message Breakdown</summary>\n\nNew release of some ml\nrelated things\n\n</details>\n\n<!-- hash: ea4bb9fd21b0a8eb32c437883158bd6ace2969022216a1106cbefe379ad95149 -->",
 		},
 	}
 
+	mockGitServer.On("GetPRComments", mock.AnythingOfType("*context.emptyCtx"), 0).Return(nil, nil)
+
 	for _, tt := range testCases {
+
 		t.Run(tt.name, func(t *testing.T) {
-			actualBreakdown, err := tt.opts.GenerateMessageBreakdown(tt.inputMessages)
+			actualBreakdown, err := tt.opts.GetMessageBreakdown(context.Background(), tt.inputMessages)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.expectedBreakdown, actualBreakdown)
 		})

--- a/pkg/domain/git.go
+++ b/pkg/domain/git.go
@@ -2,6 +2,7 @@ package domain
 
 import (
 	"context"
+	"github.com/google/go-github/v47/github"
 )
 
 const (
@@ -21,4 +22,6 @@ type GitServer interface {
 	GetPullRequestBodyFromPRNumber(ctx context.Context, prNumber int) (*string, error)
 	// CommentOnPR posts a comment on a pull request given the pr number
 	CommentOnPR(ctx context.Context, prNumber int, body string) error
+	// GetPRComments returns all comments on a pull request given the pr number
+	GetPRComments(ctx context.Context, prNumber int) ([]*github.PullRequestComment, error)
 }

--- a/pkg/domain/git.go
+++ b/pkg/domain/git.go
@@ -22,6 +22,6 @@ type GitServer interface {
 	GetPullRequestBodyFromPRNumber(ctx context.Context, prNumber int) (*string, error)
 	// CommentOnPR posts a comment on a pull request given the pr number
 	CommentOnPR(ctx context.Context, prNumber int, body string) error
-	// GetPRComments returns all comments on a pull request given the pr number
-	GetPRComments(ctx context.Context, prNumber int) ([]*github.PullRequestComment, error)
+	// GetPRComments returns all comments on a pull request given the pr number sorted by most recent comment first
+	GetPRComments(ctx context.Context, prNumber int) ([]*github.IssueComment, error)
 }

--- a/pkg/domain/mocks/GitServer.go
+++ b/pkg/domain/mocks/GitServer.go
@@ -5,6 +5,8 @@ package mocks
 import (
 	context "context"
 
+	github "github.com/google/go-github/v47/github"
+
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -25,6 +27,29 @@ func (_m *GitServer) CommentOnPR(ctx context.Context, prNumber int, body string)
 	}
 
 	return r0
+}
+
+// GetPRComments provides a mock function with given fields: ctx, prNumber
+func (_m *GitServer) GetPRComments(ctx context.Context, prNumber int) ([]*github.PullRequestComment, error) {
+	ret := _m.Called(ctx, prNumber)
+
+	var r0 []*github.PullRequestComment
+	if rf, ok := ret.Get(0).(func(context.Context, int) []*github.PullRequestComment); ok {
+		r0 = rf(ctx, prNumber)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*github.PullRequestComment)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, int) error); ok {
+		r1 = rf(ctx, prNumber)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // GetPullRequestBodyFromCommit provides a mock function with given fields: ctx, sha

--- a/pkg/domain/mocks/GitServer.go
+++ b/pkg/domain/mocks/GitServer.go
@@ -30,15 +30,15 @@ func (_m *GitServer) CommentOnPR(ctx context.Context, prNumber int, body string)
 }
 
 // GetPRComments provides a mock function with given fields: ctx, prNumber
-func (_m *GitServer) GetPRComments(ctx context.Context, prNumber int) ([]*github.PullRequestComment, error) {
+func (_m *GitServer) GetPRComments(ctx context.Context, prNumber int) ([]*github.IssueComment, error) {
 	ret := _m.Called(ctx, prNumber)
 
-	var r0 []*github.PullRequestComment
-	if rf, ok := ret.Get(0).(func(context.Context, int) []*github.PullRequestComment); ok {
+	var r0 []*github.IssueComment
+	if rf, ok := ret.Get(0).(func(context.Context, int) []*github.IssueComment); ok {
 		r0 = rf(ctx, prNumber)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]*github.PullRequestComment)
+			r0 = ret.Get(0).([]*github.IssueComment)
 		}
 	}
 


### PR DESCRIPTION
Added a hash of the messages to the comment on the PR so that Peacock can tell whether the messages have changed since the last time it ran. If they haven't change then Peacock won't post validations of the messages back to the PR.