### PR TITLE
feat: pool the addresses in a message by contact type

### DIFF
--- a/pkg/cmd/run/run.go
+++ b/pkg/cmd/run/run.go
@@ -45,7 +45,6 @@ type Options struct {
 	DryRun            bool
 	CommentValidation bool
 	Subject           string
-	PoolAddresses     bool
 
 	GitServerClient domain.GitServer
 	Git             domain.Git
@@ -85,8 +84,6 @@ func NewCmdRun() *cobra.Command {
 	cmd.Flags().BoolVarP(&o.DryRun, "dry-run", "", false, "parses the messages and feathers, returning validation as a comment on the pr. Does not send messages. PR number is required for this. Default is false")
 	cmd.Flags().BoolVarP(&o.CommentValidation, "comment-validation", "", false, "posts a comment to the pr with the validation results if successful. Default is false.")
 	cmd.Flags().StringVarP(&o.Subject, "subject", "", "", "a subject to add to the messages for the handlers that require it. If empty then a subject will be generated.")
-	cmd.Flags().BoolVarP(&o.PoolAddresses, "pool-addresses", "", false, "pools the addresses in each message by contact type to reduce the total number of messages sent - not all handlers support this. Default is false.")
-
 	return cmd
 }
 
@@ -268,20 +265,11 @@ func (o *Options) SendMessages(messages []message.Message) error {
 	return nil
 }
 
-// SendMessage sends the message using the message handlers
+// SendMessage pools the addresses of the different teams by contactType and sends the message to each
 func (o *Options) SendMessage(message message.Message) error {
-	if o.PoolAddresses {
-		return o.sendMessageByContactType(message)
-	}
-	return o.sendMessageByTeam(message)
-}
-
-// sendMessageByContactType pools the addresses of the different teams by contactType and sends the message to each
-func (o *Options) sendMessageByContactType(message message.Message) error {
 	teams := o.Config.GetTeamsByNames(message.TeamNames...)
 	// We should pool the addresses by contact type so that we only send one message per contact type
 	addressPool := o.poolAddressesByContactType(teams)
-
 	for contactType, addresses := range addressPool {
 		err := o.Handlers[contactType].Send(message.Content, o.Subject, addresses)
 		if err != nil {
@@ -298,19 +286,6 @@ func (o *Options) poolAddressesByContactType(teams []feathers.Team) map[string][
 		addressPool[team.ContactType] = append(addressPool[team.ContactType], team.Addresses...)
 	}
 	return addressPool
-}
-
-// sendMessageByTeam sends the message to each team individually
-func (o *Options) sendMessageByTeam(message message.Message) error {
-	teams := o.Config.GetTeamsByNames(message.TeamNames...)
-	for _, team := range teams {
-		err := o.Handlers[team.ContactType].Send(message.Content, o.Subject, team.Addresses)
-		if err != nil {
-			return errors.Wrapf(err, "failed to send messages to %s using %s", team.Name, team.ContactType)
-		}
-		log.Infof("Message successfully sent to %s via %s\n", team.Name, team.Addresses)
-	}
-	return nil
 }
 
 // ValidateMessagesWithConfig checks that the messages found in the pr meet the requirements of the feathers

--- a/pkg/cmd/run/run_test.go
+++ b/pkg/cmd/run/run_test.go
@@ -416,29 +416,6 @@ func TestOptions_SendMessage(t *testing.T) {
 					handlers.Slack:   slackHandler,
 					handlers.Webhook: webhookHandler,
 				},
-				PoolAddresses: false,
-				Config: &feathers.Feathers{
-					Teams: []feathers.Team{
-						{Name: "Infrastructure", ContactType: handlers.Slack, Addresses: []string{"#SlackAdd1", "#SlackAdd2"}},
-						{Name: "AllDevs", ContactType: handlers.Slack, Addresses: []string{"#SlackAdd3", "#SlackAdd4"}},
-						{Name: "Product", ContactType: handlers.Webhook, Addresses: []string{"Webhook1", "Webhook2"}},
-						{Name: "Support", ContactType: handlers.Webhook, Addresses: []string{"Webhook3", "Webhook4"}},
-					},
-				},
-			},
-			inputMessage: message.Message{
-				TeamNames: []string{"Infrastructure", "AllDevs", "Product", "Support"},
-				Content:   "Test message content",
-			},
-		},
-		{
-			name: "PoolAddresses",
-			opts: &run.Options{
-				Handlers: map[string]domain.MessageHandler{
-					handlers.Slack:   slackHandler,
-					handlers.Webhook: webhookHandler,
-				},
-				PoolAddresses: true,
 				Config: &feathers.Feathers{
 					Teams: []feathers.Team{
 						{Name: "Infrastructure", ContactType: handlers.Slack, Addresses: []string{"#SlackAdd1", "#SlackAdd2"}},
@@ -457,16 +434,8 @@ func TestOptions_SendMessage(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			if tc.opts.PoolAddresses {
-				slackHandler.On("Send", tc.inputMessage.Content, "", []string{"#SlackAdd1", "#SlackAdd2", "#SlackAdd3", "#SlackAdd4"}).Return(nil)
-				webhookHandler.On("Send", tc.inputMessage.Content, "", []string{"Webhook1", "Webhook2", "Webhook3", "Webhook4"}).Return(nil)
-			} else {
-				slackHandler.On("Send", tc.inputMessage.Content, "", []string{"#SlackAdd1", "#SlackAdd2"}).Return(nil)
-				slackHandler.On("Send", tc.inputMessage.Content, "", []string{"#SlackAdd3", "#SlackAdd4"}).Return(nil)
-				webhookHandler.On("Send", tc.inputMessage.Content, "", []string{"Webhook1", "Webhook2"}).Return(nil)
-				webhookHandler.On("Send", tc.inputMessage.Content, "", []string{"Webhook3", "Webhook4"}).Return(nil)
-
-			}
+			slackHandler.On("Send", tc.inputMessage.Content, "", []string{"#SlackAdd1", "#SlackAdd2", "#SlackAdd3", "#SlackAdd4"}).Return(nil)
+			webhookHandler.On("Send", tc.inputMessage.Content, "", []string{"Webhook1", "Webhook2", "Webhook3", "Webhook4"}).Return(nil)
 
 			err := tc.opts.SendMessage(tc.inputMessage)
 			assert.NoError(t, err)


### PR DESCRIPTION
Rather than sending one message per team in a notify header, Peacock will now pool all the addresses for all teams by contactType and only send one message (if the handler supports this).

E.g. if sending via email then one email will be sent per message (pooling all the addresses together) rather than sending one message per team