### PR TITLE
fix: hardcode ghcr.io in the charts makefile

### DIFF
--- a/charts/peacock/Makefile
+++ b/charts/peacock/Makefile
@@ -36,7 +36,7 @@ ifeq ($(OS),Darwin)
 	sed -i "" -e "s/tag:.*/tag: $(RELEASE_VERSION)/" values.yaml
 else ifeq ($(OS),Linux)
 	sed -i -e "s/version:.*/version: $(RELEASE_VERSION)/" Chart.yaml
-	sed -i -e "s|repository:.*|repository: $(DOCKER_REGISTRY)\/spring-financial-group\/peacock|" values.yaml
+	sed -i -e "s|repository:.*|repository: ghcr.io\/spring-financial-group\/peacock|" values.yaml
 	sed -i -e "s/tag:.*/tag: $(RELEASE_VERSION)/" values.yaml
 else
 	echo "platfrom $(OS) not supported to release from"


### PR DESCRIPTION
When templated in dev cluster the make file is pointing the charts to acr. Hardcoding ghcr in the makefile to fix this.