### PR TITLE
fix: feathers not found if branch deleted

### DIFF
--- a/pkg/models/pullrequest.go
+++ b/pkg/models/pullrequest.go
@@ -7,6 +7,7 @@ import (
 // PullRequestEventDTO is a data transfer object for the PullRequestEvent. It reduces the amount of data that is held
 // by the service.
 type PullRequestEventDTO struct {
+	PullRequestID int64
 	Owner         string
 	RepoName      string
 	Body          string
@@ -19,6 +20,7 @@ type PullRequestEventDTO struct {
 // MarshalPullRequestEvent marshals a github.PullRequestEvent into a PullRequestEventDTO
 func MarshalPullRequestEvent(event *github.PullRequestEvent) *PullRequestEventDTO {
 	return &PullRequestEventDTO{
+		PullRequestID: *event.PullRequest.ID,
 		Owner:         *event.Repo.Owner.Login,
 		RepoName:      *event.Repo.Name,
 		Body:          event.PullRequest.GetBody(),

--- a/pkg/webhook/handler/webhookhandler.go
+++ b/pkg/webhook/handler/webhookhandler.go
@@ -57,7 +57,7 @@ func (h *Handler) handlePullRequestOpenedEvent(_ string, _ string, event *github
 func (h *Handler) handlePullRequestClosedEvent(_ string, _ string, event *github.PullRequestEvent) error {
 	if !*event.PullRequest.Merged {
 		log.Infof("%s/PR-%d closed without merging. Skipping.", *event.Repo.Name, *event.PullRequest.Number)
-		h.useCase.CleanUp(*event.PullRequest.Head.Ref)
+		h.useCase.CleanUp(*event.PullRequest.ID)
 		return nil
 	}
 	log.Infof("%s/PR-%d closed with merge. Starting full run.", *event.Repo.Name, *event.PullRequest.Number)

--- a/pkg/webhook/usecase/webhookuc_test.go
+++ b/pkg/webhook/usecase/webhookuc_test.go
@@ -29,6 +29,7 @@ var (
 	mockCTX = context.Background()
 
 	mockPullRequestEventDTO = &models.PullRequestEventDTO{
+		PullRequestID: 100,
 		Owner:         RepoOwner,
 		RepoName:      RepoName,
 		Body:          "### Notify Infra\n\nHello infra\n\n### Notify Skisocks\n\nHello skisocks",
@@ -125,7 +126,7 @@ func TestWebHookUseCase_RunPeacock(t *testing.T) {
 		defaultSHA := "default-SHA"
 		mockSCM.On("GetLatestCommitSHAInBranch", mockCTX, mockEvent.DefaultBranch).Return(defaultSHA, nil).Once()
 		mockSCM.On("CreatePeacockCommitStatus", mockCTX, defaultSHA, domain.PendingState, domain.ReleaseContext).Return(nil).Once()
-		mockSCM.On("GetFileFromBranch", mockCTX, mockEvent.Branch, ".peacock/feathers.yaml").Return(mockFeathersData, nil).Once()
+		mockSCM.On("GetFileFromBranch", mockCTX, mockEvent.DefaultBranch, ".peacock/feathers.yaml").Return(mockFeathersData, nil).Once()
 
 		mockSCM.On("CreatePeacockCommitStatus", mockCTX, defaultSHA, domain.SuccessState, domain.ReleaseContext).Return(nil).Once()
 


### PR DESCRIPTION
GitHub can be setup to automatically deleted branches after merge in which case peacock can no longer find the feathers that correspond to the PR as they have been deleted.

This PR changes peacock so that on merge it gets the feathers from the default branch. 

I've also changed the key used to cache the feathers to the pull request ID rather than the branch name. Removes the possibility of a PR in one repo getting the feathers from another repo if the branches have the same name.