### PR TITLE
refactor: integrate Teams struct into ReleaseNotes

### DIFF
--- a/pkg/cmd/run/run.go
+++ b/pkg/cmd/run/run.go
@@ -160,7 +160,7 @@ func (o *Options) Run() error {
 	}
 
 	log.Info("Parsing messages from pull request body")
-	messages, err := o.NotesUC.ParseNotesFromMarkdown(*prBody)
+	messages, err := o.NotesUC.GetReleaseNotesFromMDAndTeams(*prBody, o.Feathers.Teams)
 	if err != nil {
 		err = errors.Wrapf(err, "failed to parse release notes from pull request")
 		o.PostErrorToPR(ctx, err)
@@ -170,14 +170,6 @@ func (o *Options) Run() error {
 	if messages == nil {
 		log.Info("No messages found in markdown, exiting")
 		return nil
-	}
-
-	log.Info("Validating messages")
-	err = o.NotesUC.ValidateReleaseNotesWithFeathers(o.Feathers, messages)
-	if err != nil {
-		err = errors.Wrapf(err, "failed validate messages with feathers")
-		o.PostErrorToPR(ctx, err)
-		return err
 	}
 
 	if o.DryRun {
@@ -203,7 +195,7 @@ func (o *Options) Run() error {
 	}
 
 	log.Info("Sending messages")
-	err = o.NotesUC.SendReleaseNotes(o.Feathers, messages)
+	err = o.NotesUC.SendReleaseNotes(o.Subject, messages)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/run/run_test.go
+++ b/pkg/cmd/run/run_test.go
@@ -258,7 +258,7 @@ func TestOptions_Run(t *testing.T) {
 			mockSCM.On("GetPullRequestBodyFromCommit", mock.AnythingOfType("*context.emptyCtx"), "SHA").Return(tt.prBody, nil).Once()
 		}
 
-		mockNotesUC.On("ParseNotesFromMarkdown", *tt.prBody).Return(mockNotes, nil)
+		mockNotesUC.On("GetReleaseNotesFromMDAndTeams", *tt.prBody).Return(mockNotes, nil)
 
 		mockNotesUC.On("ValidateReleaseNotesWithFeathers", tt.opts.Feathers, mockNotes).Return(nil)
 

--- a/pkg/domain/msgclients.go
+++ b/pkg/domain/msgclients.go
@@ -1,11 +1,9 @@
 package domain
 
-import (
-	"github.com/spring-financial-group/peacock/pkg/models"
-)
+import "github.com/spring-financial-group/peacock/pkg/models"
 
 type MessageHandler interface {
-	SendReleaseNotes(feathers *models.Feathers, messages []models.ReleaseNote) error
+	SendReleaseNotes(subject string, notes []models.ReleaseNote) error
 	IsInitialised(contactType string) bool
 }
 

--- a/pkg/domain/releasenotes.go
+++ b/pkg/domain/releasenotes.go
@@ -5,14 +5,12 @@ import (
 )
 
 type ReleaseNotesUseCase interface {
-	// ParseNotesFromMarkdown parses release notes from a markdown string
-	ParseNotesFromMarkdown(markdown string) ([]models.ReleaseNote, error)
+	// GetReleaseNotesFromMDAndTeams parses release notes from a markdown string attaching the corresponding teams
+	GetReleaseNotesFromMDAndTeams(markdown string, teamsInFeathers models.Teams) ([]models.ReleaseNote, error)
 	// GenerateHash generates a SHA256 hash of the json of a slice of release notes
 	GenerateHash(messages []models.ReleaseNote) (string, error)
 	// GenerateBreakdown generates a markdown string breaking down the release notes
 	GenerateBreakdown(notes []models.ReleaseNote, hash string, totalTeams int) (string, error)
 	// SendReleaseNotes sends release notes to their respective teams
-	SendReleaseNotes(feathers *models.Feathers, messages []models.ReleaseNote) error
-	// ValidateReleaseNotesWithFeathers checks that the relevant handlers have been registered and that the teams exist
-	ValidateReleaseNotesWithFeathers(feathers *models.Feathers, notes []models.ReleaseNote) error
+	SendReleaseNotes(subject string, notes []models.ReleaseNote) error
 }

--- a/pkg/models/releasenotes.go
+++ b/pkg/models/releasenotes.go
@@ -1,6 +1,6 @@
 package models
 
 type ReleaseNote struct {
-	TeamNames []string
-	Content   string
+	Teams   Teams
+	Content string
 }

--- a/pkg/models/team.go
+++ b/pkg/models/team.go
@@ -15,15 +15,15 @@ type Team struct {
 type Teams []Team
 
 func (ts Teams) GetTeamsByNames(names ...string) Teams {
-	var teams Teams
+	var wantedTeams Teams
 	for _, name := range names {
 		for _, t := range ts {
 			if t.Name == name {
-				teams = append(teams, t)
+				wantedTeams = append(wantedTeams, t)
 			}
 		}
 	}
-	return teams
+	return wantedTeams
 }
 
 func (ts Teams) GetAllTeamNames() []string {
@@ -50,7 +50,7 @@ func (ts Teams) GetContactTypesByTeamNames(names ...string) []string {
 	return types
 }
 
-func (ts Teams) Exists(teamNames ...string) error {
+func (ts Teams) Contains(teamNames ...string) error {
 	allTeamsInFeathers := ts.GetAllTeamNames()
 	for _, name := range teamNames {
 		if !utils.ExistsInSlice(name, allTeamsInFeathers) {
@@ -60,10 +60,9 @@ func (ts Teams) Exists(teamNames ...string) error {
 	return nil
 }
 
-func (ts Teams) GetAddressPoolByTeamNames(teamNames ...string) map[string][]string {
-	wantedTeams := ts.GetTeamsByNames(teamNames...)
+func (ts Teams) GetAddressPool() map[string][]string {
 	addressPool := make(map[string][]string, len(ts.GetAllContactTypes()))
-	for _, team := range wantedTeams {
+	for _, team := range ts {
 		addressPool[team.ContactType] = append(addressPool[team.ContactType], team.Addresses...)
 	}
 	return addressPool

--- a/pkg/releasenotes/delivery/msgclients/handler.go
+++ b/pkg/releasenotes/delivery/msgclients/handler.go
@@ -30,10 +30,10 @@ func NewMessageHandler(cfg *config.MessageHandlers) *Handler {
 	}
 }
 
-func (h *Handler) SendReleaseNotes(feathers *models.Feathers, notes []models.ReleaseNote) error {
+func (h *Handler) SendReleaseNotes(subject string, notes []models.ReleaseNote) error {
 	var errCount int
-	for _, m := range notes {
-		err := h.sendNote(feathers, m)
+	for _, n := range notes {
+		err := h.sendNote(n, subject)
 		if err != nil {
 			log.Error(err)
 			errCount++
@@ -46,11 +46,11 @@ func (h *Handler) SendReleaseNotes(feathers *models.Feathers, notes []models.Rel
 	return nil
 }
 
-func (h *Handler) sendNote(feathers *models.Feathers, note models.ReleaseNote) error {
+func (h *Handler) sendNote(note models.ReleaseNote, subject string) error {
 	// We should pool the addresses by contact type so that we only send one note per contact type
-	addressPool := feathers.Teams.GetAddressPoolByTeamNames(note.TeamNames...)
+	addressPool := note.Teams.GetAddressPool()
 	for contactType, addresses := range addressPool {
-		err := h.Clients[contactType].Send(note.Content, feathers.Config.Messages.Subject, addresses)
+		err := h.Clients[contactType].Send(note.Content, subject, addresses)
 		if err != nil {
 			return errors.Wrapf(err, "failed to send note")
 		}

--- a/pkg/releasenotes/usecase/releasenotesuc_test.go
+++ b/pkg/releasenotes/usecase/releasenotesuc_test.go
@@ -181,7 +181,7 @@ func TestParse(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-			actualMessages, err := uc.ParseNotesFromMarkdown(tt.inputMarkdown)
+			actualMessages, err := uc.GetReleaseNotesFromMDAndTeams(tt.inputMarkdown)
 			if tt.shouldError {
 				fmt.Println("expected error: " + err.Error())
 				assert.Error(t, err)

--- a/pkg/webhook/usecase/webhookuc.go
+++ b/pkg/webhook/usecase/webhookuc.go
@@ -39,6 +39,11 @@ func (w *WebHookUseCase) ValidatePeacock(e *models.PullRequestEventDTO) error {
 		return scm.HandleError(ctx, domain.ValidationContext, e.SHA, e.PROwner, errors.Wrap(err, "failed to create pending status"))
 	}
 
+	if e.Body == "" {
+		log.Infof("no text found in PR body, skipping")
+		return scm.CreatePeacockCommitStatus(ctx, e.SHA, domain.SuccessState, domain.ValidationContext)
+	}
+
 	// Get the feathers for the pull request, should cache this as this will run for any edited event
 	feathers, err := w.getFeathers(ctx, scm, e.Branch, e)
 	if err != nil {
@@ -115,6 +120,11 @@ func (w *WebHookUseCase) RunPeacock(e *models.PullRequestEventDTO) error {
 	// Set the current pipeline status to pending
 	if err = scm.CreatePeacockCommitStatus(ctx, defaultSHA, domain.PendingState, domain.ReleaseContext); err != nil {
 		return scm.HandleError(ctx, domain.ReleaseContext, defaultSHA, e.PROwner, errors.Wrap(err, "failed to create pending status"))
+	}
+
+	if e.Body == "" {
+		log.Infof("no text found in PR body, skipping")
+		return scm.CreatePeacockCommitStatus(ctx, defaultSHA, domain.SuccessState, domain.ReleaseContext)
 	}
 
 	// Get the feathers for the pull request, should cache this as this will run for any edited event

--- a/pkg/webhook/usecase/webhookuc_test.go
+++ b/pkg/webhook/usecase/webhookuc_test.go
@@ -106,7 +106,7 @@ func TestWebHookUseCase_ValidatePeacock(t *testing.T) {
 		mockSCM.On("CommentOnPR", mockCTX, mock.Anything).Return(nil).Once()
 		mockSCM.On("CreatePeacockCommitStatus", mockCTX, mockEvent.SHA, domain.SuccessState, domain.ValidationContext).Return(nil).Once()
 
-		mockNotesUC.On("ParseNotesFromMarkdown", prBody).Return(mockNotes, nil)
+		mockNotesUC.On("GetReleaseNotesFromMDAndTeams", prBody).Return(mockNotes, nil)
 		mockNotesUC.On("ValidateReleaseNotesWithFeathers", mockFeathers, mockNotes).Return(nil)
 		mockNotesUC.On("GenerateHash", mockNotes).Return(mockHash, nil)
 		mockNotesUC.On("GenerateBreakdown", mockNotes, mockHash, 2).Return("", nil)
@@ -144,7 +144,7 @@ func TestWebHookUseCase_RunPeacock(t *testing.T) {
 
 		mockSCM.On("CreatePeacockCommitStatus", mockCTX, defaultSHA, domain.SuccessState, domain.ReleaseContext).Return(nil).Once()
 
-		mockNotesUC.On("ParseNotesFromMarkdown", prBody).Return(mockNotes, nil)
+		mockNotesUC.On("GetReleaseNotesFromMDAndTeams", prBody).Return(mockNotes, nil)
 		mockNotesUC.On("ValidateReleaseNotesWithFeathers", mockFeathers, mockNotes).Return(nil)
 		mockNotesUC.On("SendReleaseNotes", mockFeathers, mockNotes).Return(nil)
 


### PR DESCRIPTION
Integrating Teams struct into ReleaseNotes struct. This removes any of the nasty teamName parsing I was doing before actually sending the release notes, this now gets done when we actually read then notes from the PR body. Any Team validation that is done is now also done at the point of parsing, removing code duplication between the cli and the service.

This has meant that Peacock needs to get the feathers before parsing the notes - will increase the number of API calls. 

Also added a check to make sure that the PR body actually has text in it before we do anything, will reduce API calls.