### PR TITLE
fix: filter out events that occur on closed/merged PRs

### DIFF
--- a/pkg/models/pullrequest.go
+++ b/pkg/models/pullrequest.go
@@ -4,6 +4,12 @@ import (
 	"github.com/google/go-github/v48/github"
 )
 
+// Pull request states
+const (
+	OpenState   = "open"
+	ClosedState = "closed"
+)
+
 // PullRequestEventDTO is a data transfer object for the PullRequestEvent. It reduces the amount of data that is held
 // by the service.
 type PullRequestEventDTO struct {

--- a/pkg/webhook/handler/webhookhandler.go
+++ b/pkg/webhook/handler/webhookhandler.go
@@ -53,6 +53,10 @@ func (h *Handler) HandleEvents(c *gin.Context) {
 // handlePullRequestSyncEvent starts a dry-run when a PR has been synchronized (e.g. new commits pushed)
 func (h *Handler) handlePullRequestSyncEvent(_ string, _ string, event *github.PullRequestEvent) error {
 	log.Infof("%s/PR-%d synced. Starting dry-run.", *event.Repo.Name, *event.PullRequest.Number)
+	if *event.PullRequest.State == models.ClosedState {
+		log.Info("PR is closed. Skipping.")
+		return nil
+	}
 	return h.useCase.ValidatePeacock(models.MarshalPullRequestEvent(event))
 }
 
@@ -77,5 +81,10 @@ func (h *Handler) handlePullRequestClosedEvent(_ string, _ string, event *github
 // handlePullRequestEditEvent starts a dry-run when a PR has been edited (e.g. body/title changed)
 func (h *Handler) handlePullRequestEditEvent(_ string, _ string, event *github.PullRequestEvent) error {
 	log.Infof("%s/PR-%d edited. Starting dry-run.", *event.Repo.Name, *event.PullRequest.Number)
+	if *event.PullRequest.State == models.ClosedState {
+		// No need to handle closed
+		log.Info("PR is closed. Skipping.")
+		return nil
+	}
 	return h.useCase.ValidatePeacock(models.MarshalPullRequestEvent(event))
 }


### PR DESCRIPTION
Stops peacock from running on closed/merged PRs