### PR TITLE
fix: add linebreaks to html when newline is in paragraph

### DIFF
--- a/pkg/markdown/markdown.go
+++ b/pkg/markdown/markdown.go
@@ -55,7 +55,7 @@ func ConvertToSlack(markdown string) string {
 
 // ConvertToHTML converts the Markdown syntax into HTML and sanitises the result.
 func ConvertToHTML(markdown string) string {
-	mdParser := md.New(md.HTML(true))
+	mdParser := md.New(md.HTML(true), md.Breaks(true))
 	unsafeHTML := mdParser.RenderToString([]byte(markdown))
 	safeHTML := bluemonday.UGCPolicy().Sanitize(unsafeHTML)
 

--- a/pkg/markdown/markdown_test.go
+++ b/pkg/markdown/markdown_test.go
@@ -23,7 +23,7 @@ func TestMarkdown_Converters(t *testing.T) {
 			name:          "CarriageReturn",
 			inputMarkdown: "First Sentence\r\nSecond Sentence\r\n",
 			expectedSlack: "First Sentence\nSecond Sentence\n",
-			expectedHTML:  "<p>First Sentence\nSecond Sentence</p>\n",
+			expectedHTML:  "<p>First Sentence<br>\nSecond Sentence</p>\n",
 		},
 		{
 			name:          "HeadingReplacement",
@@ -47,13 +47,13 @@ func TestMarkdown_Converters(t *testing.T) {
 			name:          "BoldReplacement(**)",
 			inputMarkdown: "**Bold Title**\n**Other Bold Title**",
 			expectedSlack: "*Bold Title*\n*Other Bold Title*",
-			expectedHTML:  "<p><strong>Bold Title</strong>\n<strong>Other Bold Title</strong></p>\n",
+			expectedHTML:  "<p><strong>Bold Title</strong><br>\n<strong>Other Bold Title</strong></p>\n",
 		},
 		{
 			name:          "BoldReplacement(__)",
 			inputMarkdown: "__Bold Title__\n__Other Bold Title__",
 			expectedSlack: "*Bold Title*\n*Other Bold Title*",
-			expectedHTML:  "<p><strong>Bold Title</strong>\n<strong>Other Bold Title</strong></p>\n",
+			expectedHTML:  "<p><strong>Bold Title</strong><br>\n<strong>Other Bold Title</strong></p>\n",
 		},
 		{
 			name:          "URLReplacement",


### PR DESCRIPTION
Previously the HTML conversion ignored newline characters within a paragraph from Markdown meaning that the output HTML didn't format in the same way as the input Markdown. 

This PR changes the parsing so that a linebreak is added for every newline character in a paragraph. 