### PR TITLE
fix: add nodeSelector/affinity/annotations to deployment chart

### DIFF
--- a/charts/peacock/templates/deployment.yaml
+++ b/charts/peacock/templates/deployment.yaml
@@ -102,4 +102,16 @@ spec:
 {{- range $pval := .Values.jx.imagePullSecrets }}
       - name: {{ quote $pval }}
 {{- end }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- end }}


### PR DESCRIPTION
Tried to put Peacock on the Infrastructure node pool with [this PR](https://github.com/spring-financial-group/JX3_Azure_Vault_Dev_Cluster/pull/15068). Failed to actually do anything as the corresponding values were missing from the deployment template.