### PR TITLE
feat: move to oss pipeline

### DIFF
--- a/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/.lighthouse/jenkins-x/pullrequest.yaml
@@ -27,7 +27,7 @@ spec:
               cpu: 400m
               memory: 600Mi
         - image: ghcr.io/jenkins-x/jx-boot:3.2.197
-          name: override-variables
+          name: override-docker-registry
           resources: {}
           script: |
             #!/usr/bin/env sh

--- a/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/.lighthouse/jenkins-x/pullrequest.yaml
@@ -46,13 +46,8 @@ spec:
         - image: uses:spring-financial-group/DevOps/pipelines/preview-copy-secrets.yaml@main
           name: ""
           resources: {}
-        - image: ghcr.io/jenkins-x-plugins/jx-preview:0.0.231
-          name: promote-jx-preview
+        - name: promote-jx-preview
           resources: {}
-          script: |
-            #!/usr/bin/env sh
-            source .jx/variables.sh
-            jx preview create
   podTemplate: {}
   serviceAccountName: tekton-bot
   timeout: 1h0m0s

--- a/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/.lighthouse/jenkins-x/pullrequest.yaml
@@ -40,7 +40,7 @@ spec:
             make build
         - image: uses:spring-financial-group/DevOps/pipelines/sonar-scanner-pr.yaml@main
           name: ""
-        - image: uses:spring-financial-group/DevOps/pipelines/build-scan-push-oss.yaml@3e4e7239ef25486867f1f69e9f519fe692e29051
+        - image: uses:spring-financial-group/DevOps/pipelines/build-scan-push-oss.yaml@d7faa2ba2f35b3e46d90dcbe94d40b0591595b1c
           name: ""
           resources: {}
         - image: uses:spring-financial-group/DevOps/pipelines/preview-copy-secrets.yaml@main

--- a/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/.lighthouse/jenkins-x/pullrequest.yaml
@@ -40,7 +40,7 @@ spec:
             make build
         - image: uses:spring-financial-group/DevOps/pipelines/sonar-scanner-pr.yaml@main
           name: ""
-        - image: uses:spring-financial-group/DevOps/pipelines/build-scan-push-oss-pr.yaml@db941e6a8f4afdfa109e587677361df4d751ead0
+        - image: uses:spring-financial-group/DevOps/pipelines/build-scan-push-oss-pr.yaml@dc434087154afa86fe726de4b438aa4b83c6cf4e
           name: ""
           resources: {}
         - image: uses:spring-financial-group/DevOps/pipelines/preview-copy-secrets.yaml@main

--- a/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/.lighthouse/jenkins-x/pullrequest.yaml
@@ -40,7 +40,7 @@ spec:
             make build
         - image: uses:spring-financial-group/DevOps/pipelines/sonar-scanner-pr.yaml@main
           name: ""
-        - image: uses:spring-financial-group/DevOps/pipelines/build-scan-push-oss.yaml@d7faa2ba2f35b3e46d90dcbe94d40b0591595b1c
+        - image: uses:spring-financial-group/DevOps/pipelines/build-scan-push-oss.yaml@main
           name: ""
           resources: {}
         - image: uses:spring-financial-group/DevOps/pipelines/preview-copy-secrets.yaml@main

--- a/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/.lighthouse/jenkins-x/pullrequest.yaml
@@ -40,7 +40,7 @@ spec:
             make build
         - image: uses:spring-financial-group/DevOps/pipelines/sonar-scanner-pr.yaml@main
           name: ""
-        - image: uses:spring-financial-group/DevOps/pipelines/build-scan-push-oss-pr.yaml@c08ccffb01f97e15fa69dbdfecae6a10d579681f
+        - image: uses:spring-financial-group/DevOps/pipelines/build-scan-push-oss-pr.yaml@db941e6a8f4afdfa109e587677361df4d751ead0
           name: ""
           resources: {}
         - image: uses:spring-financial-group/DevOps/pipelines/preview-copy-secrets.yaml@main

--- a/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/.lighthouse/jenkins-x/pullrequest.yaml
@@ -16,9 +16,6 @@ spec:
             # override limits for all containers here
             limits: {}
           workingDir: /workspace/source
-          volumeMounts:
-            - mountPath: /oss-docker-config
-              name: oss-docker-config
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone-pr.yaml@versionStream
           name: ""
@@ -43,14 +40,9 @@ spec:
             make build
         - image: uses:spring-financial-group/DevOps/pipelines/sonar-scanner-pr.yaml@main
           name: ""
-        - image: gcr.io/kaniko-project/executor:v1.9.1-debug
-          name: build-container-build
+        - image: uses:spring-financial-group/DevOps/pipelines/build-scan-push-oss-pr.yaml@c08ccffb01f97e15fa69dbdfecae6a10d579681f
+          name: ""
           resources: {}
-          script: |
-            #!/busybox/sh
-            source .jx/variables.sh
-            cp /oss-docker-config/config.json /kaniko/.docker/config.json
-            /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
         - image: uses:spring-financial-group/DevOps/pipelines/preview-copy-secrets.yaml@main
           name: ""
           resources: {}
@@ -61,13 +53,6 @@ spec:
             #!/usr/bin/env sh
             source .jx/variables.sh
             jx preview create
-        volumes:
-          - name: oss-docker-config
-            secret:
-              secretName: tekton-oss-container-registry-auth
-              items:
-                - key: .dockerconfigjson
-                  path: config.json
   podTemplate: {}
   serviceAccountName: tekton-bot
   timeout: 1h0m0s

--- a/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/.lighthouse/jenkins-x/pullrequest.yaml
@@ -40,7 +40,7 @@ spec:
             make build
         - image: uses:spring-financial-group/DevOps/pipelines/sonar-scanner-pr.yaml@main
           name: ""
-        - image: uses:spring-financial-group/DevOps/pipelines/build-scan-push-oss-pr.yaml@dc434087154afa86fe726de4b438aa4b83c6cf4e
+        - image: uses:spring-financial-group/DevOps/pipelines/build-scan-push-oss.yaml@3e4e7239ef25486867f1f69e9f519fe692e29051
           name: ""
           resources: {}
         - image: uses:spring-financial-group/DevOps/pipelines/preview-copy-secrets.yaml@main

--- a/.lighthouse/jenkins-x/release.yaml
+++ b/.lighthouse/jenkins-x/release.yaml
@@ -83,7 +83,7 @@ spec:
             gh release upload v$VERSION ./build/win/peacock-windows-amd64.exe
             mv ./build/darwin/peacock ./build/darwin/peacock-darwin
             gh release upload v$VERSION ./build/darwin/peacock-darwin
-        - image: uses:spring-financial-group/DevOps/pipelines/build-scan-push-oss-release.yaml@db941e6a8f4afdfa109e587677361df4d751ead0
+        - image: uses:spring-financial-group/DevOps/pipelines/build-scan-push-oss-release.yaml@dc434087154afa86fe726de4b438aa4b83c6cf4e
           resources: {}
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/updatebot/release.yaml@versionStream
           resources: {}

--- a/.lighthouse/jenkins-x/release.yaml
+++ b/.lighthouse/jenkins-x/release.yaml
@@ -34,7 +34,7 @@ spec:
               cpu: 400m
               memory: 600Mi
         - image: ghcr.io/jenkins-x/jx-boot:3.2.197
-          name: override-variables
+          name: override-docker-registry
           resources: {}
           script: |
             #!/usr/bin/env sh

--- a/.lighthouse/jenkins-x/release.yaml
+++ b/.lighthouse/jenkins-x/release.yaml
@@ -83,7 +83,7 @@ spec:
             gh release upload v$VERSION ./build/win/peacock-windows-amd64.exe
             mv ./build/darwin/peacock ./build/darwin/peacock-darwin
             gh release upload v$VERSION ./build/darwin/peacock-darwin
-        - image: uses:spring-financial-group/DevOps/pipelines/build-scan-push-oss.yaml@d7faa2ba2f35b3e46d90dcbe94d40b0591595b1c
+        - image: uses:spring-financial-group/DevOps/pipelines/build-scan-push-oss.yaml@main
           resources: {}
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/updatebot/release.yaml@versionStream
           resources: {}

--- a/.lighthouse/jenkins-x/release.yaml
+++ b/.lighthouse/jenkins-x/release.yaml
@@ -17,9 +17,6 @@ spec:
             # override limits for all containers here
             limits: {}
           workingDir: /workspace/source
-          volumeMounts:
-            - mountPath: /oss-docker-config
-              name: oss-docker-config
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone.yaml@versionStream
           name: ""
@@ -86,23 +83,10 @@ spec:
             gh release upload v$VERSION ./build/win/peacock-windows-amd64.exe
             mv ./build/darwin/peacock ./build/darwin/peacock-darwin
             gh release upload v$VERSION ./build/darwin/peacock-darwin
-        - image: gcr.io/kaniko-project/executor:v1.9.1-debug
-          name: build-container-build
+        - image: uses:spring-financial-group/DevOps/pipelines/build-scan-push-oss-release.yaml@c08ccffb01f97e15fa69dbdfecae6a10d579681f
           resources: {}
-          script: |
-            #!/busybox/sh
-            source .jx/variables.sh
-            cp /oss-docker-config/config.json /kaniko/.docker/config.json
-            /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:latest
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/updatebot/release.yaml@versionStream
           resources: {}
-        volumes:
-          - name: oss-docker-config
-            secret:
-              secretName: tekton-oss-container-registry-auth
-              items:
-                - key: .dockerconfigjson
-                  path: config.json
   podTemplate: {}
   serviceAccountName: tekton-bot
   timeout: 12h0m0s

--- a/.lighthouse/jenkins-x/release.yaml
+++ b/.lighthouse/jenkins-x/release.yaml
@@ -83,7 +83,7 @@ spec:
             gh release upload v$VERSION ./build/win/peacock-windows-amd64.exe
             mv ./build/darwin/peacock ./build/darwin/peacock-darwin
             gh release upload v$VERSION ./build/darwin/peacock-darwin
-        - image: uses:spring-financial-group/DevOps/pipelines/build-scan-push-oss.yaml3e4e7239ef25486867f1f69e9f519fe692e29051
+        - image: uses:spring-financial-group/DevOps/pipelines/build-scan-push-oss.yaml@d7faa2ba2f35b3e46d90dcbe94d40b0591595b1c
           resources: {}
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/updatebot/release.yaml@versionStream
           resources: {}

--- a/.lighthouse/jenkins-x/release.yaml
+++ b/.lighthouse/jenkins-x/release.yaml
@@ -83,7 +83,7 @@ spec:
             gh release upload v$VERSION ./build/win/peacock-windows-amd64.exe
             mv ./build/darwin/peacock ./build/darwin/peacock-darwin
             gh release upload v$VERSION ./build/darwin/peacock-darwin
-        - image: uses:spring-financial-group/DevOps/pipelines/build-scan-push-oss-release.yaml@dc434087154afa86fe726de4b438aa4b83c6cf4e
+        - image: uses:spring-financial-group/DevOps/pipelines/build-scan-push-oss.yaml3e4e7239ef25486867f1f69e9f519fe692e29051
           resources: {}
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/updatebot/release.yaml@versionStream
           resources: {}

--- a/.lighthouse/jenkins-x/release.yaml
+++ b/.lighthouse/jenkins-x/release.yaml
@@ -83,7 +83,7 @@ spec:
             gh release upload v$VERSION ./build/win/peacock-windows-amd64.exe
             mv ./build/darwin/peacock ./build/darwin/peacock-darwin
             gh release upload v$VERSION ./build/darwin/peacock-darwin
-        - image: uses:spring-financial-group/DevOps/pipelines/build-scan-push-oss-release.yaml@c08ccffb01f97e15fa69dbdfecae6a10d579681f
+        - image: uses:spring-financial-group/DevOps/pipelines/build-scan-push-oss-release.yaml@db941e6a8f4afdfa109e587677361df4d751ead0
           resources: {}
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/updatebot/release.yaml@versionStream
           resources: {}


### PR DESCRIPTION
Migrates to `build-scan-push-oss` and generally tidies the pipelines