### PR TITLE
test: add image conversion test

### DIFF
--- a/pkg/markdown/markdown_test.go
+++ b/pkg/markdown/markdown_test.go
@@ -99,9 +99,9 @@ func TestMarkdown_Converters(t *testing.T) {
 		},
 		{
 			name:          "ImageConversion",
-			inputMarkdown: "However, when they click proceed, a new dialog appears:  \n\n![image](https://github.com/user-attachments/assets/fc9c1ee1-a8a1-4006-b46c-f1eb94c9c60f)",
-			expectedSlack: "However, when they click proceed, a new dialog appears:  \n\n!<https://github.com/user-attachments/assets/fc9c1ee1-a8a1-4006-b46c-f1eb94c9c60f|image>",
-			expectedHTML:  "<p>However, when they click proceed, a new dialog appears:</p>\n<p><img src=\"https://github.com/user-attachments/assets/fc9c1ee1-a8a1-4006-b46c-f1eb94c9c60f\" alt=\"image\"></p>\n",
+			inputMarkdown: "However, when they click proceed, a new dialog appears:  \n\n![800px-Sunflower_from_Silesia2](https://github.com/user-attachments/assets/08ee90e0-8b35-4072-9656-0435a5126614)",
+			expectedSlack: "However, when they click proceed, a new dialog appears:  \n\n!<https://github.com/user-attachments/assets/08ee90e0-8b35-4072-9656-0435a5126614|800px-Sunflower_from_Silesia2>",
+			expectedHTML:  "<p>However, when they click proceed, a new dialog appears:</p>\n<p><img src=\"https://github.com/user-attachments/assets/08ee90e0-8b35-4072-9656-0435a5126614\" alt=\"800px-Sunflower_from_Silesia2\"></p>\n",
 		},
 	}
 

--- a/pkg/markdown/markdown_test.go
+++ b/pkg/markdown/markdown_test.go
@@ -97,6 +97,12 @@ func TestMarkdown_Converters(t *testing.T) {
 			expectedSlack: "<spring-financial-group/mqube-property-service#770|https://github.com/spring-financial-group/mqube-property-service/pull/770>",
 			expectedHTML:  "<p>spring-financial-group/mqube-property-service#770</p>\n",
 		},
+		{
+			name:          "ImageConversion",
+			inputMarkdown: "However, when they click proceed, a new dialog appears:  \n\n![image](https://github.com/user-attachments/assets/fc9c1ee1-a8a1-4006-b46c-f1eb94c9c60f)",
+			expectedSlack: "However, when they click proceed, a new dialog appears:  \n\n!<https://github.com/user-attachments/assets/fc9c1ee1-a8a1-4006-b46c-f1eb94c9c60f|image>",
+			expectedHTML:  "<p>However, when they click proceed, a new dialog appears:</p>\n<p><img src=\"https://github.com/user-attachments/assets/fc9c1ee1-a8a1-4006-b46c-f1eb94c9c60f\" alt=\"image\"></p>\n",
+		},
 	}
 
 	for _, tt := range testCases {


### PR DESCRIPTION
### Notify TestWebhook1

Hi All,

We are releasing some changes to the direct debit flow 🌊 

What does this mean for you lovely broker support people? In an ideal world, nothing! :D

However, here is an explanation of the new flow in case you do get any queries from our wonderful brokers.

### Broker Journey
When the broker enters direct debit details for an applicant, there are three potential states for verifying if these belong to the applicant:

#### Passed
If everything passes, then happy days, everything will work like normal and the broker will be able to submit.

#### Failed
If it fails, then they will see the following message:  

![419433945-e2b76057-0f1f-4a5c-8276-a6b71431fb5e](https://private-user-images.githubusercontent.com/89483637/419440206-485fbb6b-2c40-48d8-99cd-11975fb49aae.jpg?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NDExNzU3NjEsIm5iZiI6MTc0MTE3NTQ2MSwicGF0aCI6Ii84OTQ4MzYzNy80MTk0NDAyMDYtNDg1ZmJiNmItMmM0MC00OGQ4LTk5Y2QtMTE5NzVmYjQ5YWFlLmpwZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNTAzMDUlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjUwMzA1VDExNTEwMVomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTU5NmFmZjEyN2FhOWZmMzJjMWMwNDRiMTQxYzE4Y2E4OTUzODc4YjA0NjU3NjExNWY4ZDY2N2VkYzEzMGVjMDkmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.OJDifrbO9CRzw9wv1S2ZaQxrzX8FSYdzJfVc3Mq4slE)

This means that bank wizard & our rules around the verification have failed, meaning that we do not believe these bank details belong to the applicant(s) on the case. Therefore, we block submission and they will need to amend these details to ones that pass our verification.

#### Unable to Check
Finally, if we get a status back from bank wizard that indicates they were unable to check the details, then we go for a different kind of validation... document requirements!

A new document requirement will be added to the case that looks like this:  

![419158712-588b8adf-0281-48e0-9d15-aa48da2efba0](https://private-user-images.githubusercontent.com/88484606/419434013-1283022f-dcef-4d3f-88ff-3e647416e3e5.jpg?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NDExNzUxODMsIm5iZiI6MTc0MTE3NDg4MywicGF0aCI6Ii84ODQ4NDYwNi80MTk0MzQwMTMtMTI4MzAyMmYtZGNlZi00ZDNmLTg4ZmYtM2U2NDc0MTZlM2U1LmpwZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNTAzMDUlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjUwMzA1VDExNDEyM1omWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTE2NDQyNjhjZDViN2NkN2UwN2Y5MGI0ZWMxOGRlMWMyYTk0MDMwZTg0ZmM1YTNkMzdiMzkyMzA1ZTJhNDUwYTcmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.3RfrsZZJvMI0tVzxALW-h-jkLSqIIDfL9nLSm55fP-I)

_p.s. this does not automatically match for now, so needs to be matched by the broker. However, we do have plans to roll out automatic matching for this document soon enough_

### Applicant Case Acceptance
The applicant acceptance screen has now changed as well. At first it looks the same as before when the applicant logs in and goes to their home page:  

![419160494-fddf37f5-0aa6-4c78-abf5-4968677d09f9](https://private-user-images.githubusercontent.com/88484606/419434058-c0cd476c-3108-42ca-825a-f5a7c7638bd1.jpg?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NDExNzUyMDQsIm5iZiI6MTc0MTE3NDkwNCwicGF0aCI6Ii84ODQ4NDYwNi80MTk0MzQwNTgtYzBjZDQ3NmMtMzEwOC00MmNhLTgyNWEtZjVhN2M3NjM4YmQxLmpwZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNTAzMDUlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjUwMzA1VDExNDE0NFomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTU4NTMyZTU2NzAxOTlkODQ3MmE5N2IxZjExMzlmOTliZGZjODA2MjM5NWMyNTAyN2U0YWE2ZjdjZDY2ODkxY2UmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.PmI1XplO7i-kSDBZ3tactbP-8TUfDm8woO5q7j3EJGg)

However, when they click proceed, a new dialog appears:  

![419160294-fc9c1ee1-a8a1-4006-b46c-f1eb94c9c60f](https://private-user-images.githubusercontent.com/88484606/419434368-f59d11db-7d61-4b6a-a8e3-6842b3242506.jpg?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NDExNzUyMTYsIm5iZiI6MTc0MTE3NDkxNiwicGF0aCI6Ii84ODQ4NDYwNi80MTk0MzQzNjgtZjU5ZDExZGItN2Q2MS00YjZhLWE4ZTMtNjg0MmIzMjQyNTA2LmpwZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNTAzMDUlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjUwMzA1VDExNDE1NlomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPWFkZjczYWRjNWNkMGUwYjExNDEzYjJlNzgyM2U4Zjk5MTVlNzEwNDY3ODBjNjA3YWFlMjc4Y2Q4YWM1NmVmYjImWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.FpmUewKDOrD-fevnxuii-gIWpcbU29en8tsGihHsibY)

They now have to click the three checkboxes to confirm everything, and then click proceed. We are doing this to remove the need for the direct debit instruction document.

If you have any questions about this process, feel free to ask Zack / Isaac through teams or (preferably) in the #support-core Slack channel!

Thanks,
Zack
