### PR TITLE
feat: remove bot generated text from messages

### DIFF
--- a/pkg/releasenotes/usecase/releasenotesuc.go
+++ b/pkg/releasenotes/usecase/releasenotesuc.go
@@ -67,11 +67,22 @@ func (uc *UseCase) GetReleaseNotesFromMDAndTeams(markdown string, teamsInFeather
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to get teams by name")
 		}
-
+		m = uc.removeBotGeneratedText(m)
 		notes[i].Content = strings.TrimSpace(m)
 		notes[i].Teams = teamsInNote
 	}
 	return notes, nil
+}
+
+var (
+	// This regex is used to find all the bot generated text in the markdown
+	// Bot generated text is of the form `[//]: # (some-bot-tag)`
+	botGeneratedTextRegex = regexp.MustCompile(`\[//\]: # \((.*)\)`)
+)
+
+func (uc *UseCase) removeBotGeneratedText(text string) string {
+	// We want to remove all of these from the text and
+	return botGeneratedTextRegex.ReplaceAllString(text, "")
 }
 
 func (uc *UseCase) getAndValidateTeamsByNames(teamNames []string, teamsInFeathers models.Teams) (models.Teams, error) {

--- a/pkg/releasenotes/usecase/releasenotesuc_test.go
+++ b/pkg/releasenotes/usecase/releasenotesuc_test.go
@@ -225,6 +225,20 @@ func TestParse(t *testing.T) {
 			expectedNotes: nil,
 			shouldError:   true,
 		},
+		{
+			name:          "RemoveBotGeneratedText",
+			inputMarkdown: "### Notify infrastructure\nTest Content\n\n[//]: # (some-bot-content)\n### Notify devs\nMore Test Content",
+			expectedNotes: []models.ReleaseNote{
+				{
+					Teams:   models.Teams{infraTeam},
+					Content: "Test Content",
+				},
+				{
+					Teams:   models.Teams{devsTeam},
+					Content: "More Test Content",
+				},
+			},
+		},
 	}
 
 	for _, tt := range testCases {


### PR DESCRIPTION
### Changes
- Adds regex for matching and removing any bot generated lines from messages

### Context
These lines are becoming more prevelant in our PR descriptions so need to make sure we don't accidentally send the line to a team (especially as they are not viewable to the PR creator)