### PR TITLE
fix: remove preceding newline character

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,8 +1,4 @@
 approvers:
-- mqube-bot
-- Skisocks
-- tomhobson
+- go
 reviewers:
-- mqube-bot
-- Skisocks
-- tomhobson
+- go

--- a/pkg/releasenotes/usecase/releasenotesuc.go
+++ b/pkg/releasenotes/usecase/releasenotesuc.go
@@ -77,7 +77,7 @@ func (uc *UseCase) GetReleaseNotesFromMDAndTeams(markdown string, teamsInFeather
 var (
 	// This regex is used to find all the bot generated text in the markdown
 	// Bot generated text is of the form `[//]: # (some-bot-tag)`
-	botGeneratedTextRegex = regexp.MustCompile(`\[//\]: # \((.*)\)`)
+	botGeneratedTextRegex = regexp.MustCompile(`\n\[//\]: # \((.*)\)`)
 )
 
 func (uc *UseCase) removeBotGeneratedText(text string) string {

--- a/pkg/releasenotes/usecase/releasenotesuc_test.go
+++ b/pkg/releasenotes/usecase/releasenotesuc_test.go
@@ -227,11 +227,11 @@ func TestParse(t *testing.T) {
 		},
 		{
 			name:          "RemoveBotGeneratedText",
-			inputMarkdown: "### Notify infrastructure\nTest Content\n\n[//]: # (some-bot-content)\n### Notify devs\nMore Test Content",
+			inputMarkdown: "### Notify infrastructure\nTest Content\n\n[//]: # (some-bot-content)\nAnother bit of content\n### Notify devs\nMore Test Content",
 			expectedNotes: []models.ReleaseNote{
 				{
 					Teams:   models.Teams{infraTeam},
-					Content: "Test Content",
+					Content: "Test Content\n\nAnother bit of content",
 				},
 				{
 					Teams:   models.Teams{devsTeam},


### PR DESCRIPTION
### Changes
- For bot markers match and remove the preceding newline character so that messages are consistent
- Update OWNERS file