### PR TITLE
fix: maybe remove the preceeding newline if it exists

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,3 @@
+foreignAliases:
+- name: mqube-community
+  org: spring-financial-group

--- a/pkg/releasenotes/usecase/releasenotesuc.go
+++ b/pkg/releasenotes/usecase/releasenotesuc.go
@@ -77,7 +77,7 @@ func (uc *UseCase) GetReleaseNotesFromMDAndTeams(markdown string, teamsInFeather
 var (
 	// This regex is used to find all the bot generated text in the markdown
 	// Bot generated text is of the form `[//]: # (some-bot-tag)`
-	botGeneratedTextRegex = regexp.MustCompile(`\n\[//\]: # \((.*)\)`)
+	botGeneratedTextRegex = regexp.MustCompile(`\n?\[//\]: # \((.*)\)`)
 )
 
 func (uc *UseCase) removeBotGeneratedText(text string) string {

--- a/pkg/releasenotes/usecase/releasenotesuc_test.go
+++ b/pkg/releasenotes/usecase/releasenotesuc_test.go
@@ -227,7 +227,7 @@ func TestParse(t *testing.T) {
 		},
 		{
 			name:          "RemoveBotGeneratedText",
-			inputMarkdown: "### Notify infrastructure\nTest Content\n\n[//]: # (some-bot-content)\nAnother bit of content\n### Notify devs\nMore Test Content",
+			inputMarkdown: "### Notify infrastructure\n[//]: # (beaver-start)\nTest Content\n\n[//]: # (some-bot-content)\nAnother bit of content\n### Notify devs\nMore Test Content",
 			expectedNotes: []models.ReleaseNote{
 				{
 					Teams:   models.Teams{infraTeam},


### PR DESCRIPTION
### Changes
- Add `?` quantifiter to `botGeneratedTextRegex` to maybe match the preceeding newline character

### Context
Seeing squarks with the bot text in. It's not being removed as the regex expects a newline character and that doesn't exist if the bot comment is at the start of the message.