### PR TITLE
feat: merge release notes if the teams are equal

### DIFF
--- a/pkg/cmd/run/run.go
+++ b/pkg/cmd/run/run.go
@@ -160,7 +160,7 @@ func (o *Options) Run() error {
 	}
 
 	log.Info("Parsing messages from pull request body")
-	messages, err := o.NotesUC.GetReleaseNotesFromMDAndTeams(*prBody, o.Feathers.Teams)
+	messages, err := o.NotesUC.GetReleaseNotesFromMarkdownAndTeamsInFeathers(*prBody, o.Feathers.Teams)
 	if err != nil {
 		err = errors.Wrapf(err, "failed to parse release notes from pull request")
 		o.PostErrorToPR(ctx, err)

--- a/pkg/cmd/run/run_test.go
+++ b/pkg/cmd/run/run_test.go
@@ -267,7 +267,7 @@ func TestOptions_Run(t *testing.T) {
 			mockSCM.On("GetPullRequestBodyFromCommit", mock.Anything, "spring-financial-group", "peacock", "SHA").Return(tt.prBody, nil).Once()
 		}
 
-		mockNotesUC.On("GetReleaseNotesFromMDAndTeams", *tt.prBody, allTeams).Return(mockNotes, nil)
+		mockNotesUC.On("GetReleaseNotesFromMarkdownAndTeamsInFeathers", *tt.prBody, allTeams).Return(mockNotes, nil)
 
 		if !tt.opts.DryRun {
 			mockNotesUC.On("SendReleaseNotes", "New Release Notes for peacock", mockNotes).Return(nil).Once()

--- a/pkg/domain/mocks/ReleaseNotesUseCase.go
+++ b/pkg/domain/mocks/ReleaseNotesUseCase.go
@@ -86,12 +86,12 @@ func (_m *ReleaseNotesUseCase) GetMarkdownFromReleaseNotes(notes []models.Releas
 	return r0
 }
 
-// GetReleaseNotesFromMDAndTeams provides a mock function with given fields: markdown, teamsInFeathers
-func (_m *ReleaseNotesUseCase) GetReleaseNotesFromMDAndTeams(markdown string, teamsInFeathers models.Teams) ([]models.ReleaseNote, error) {
+// GetReleaseNotesFromMarkdownAndTeamsInFeathers provides a mock function with given fields: markdown, teamsInFeathers
+func (_m *ReleaseNotesUseCase) GetReleaseNotesFromMarkdownAndTeamsInFeathers(markdown string, teamsInFeathers models.Teams) ([]models.ReleaseNote, error) {
 	ret := _m.Called(markdown, teamsInFeathers)
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetReleaseNotesFromMDAndTeams")
+		panic("no return value specified for GetReleaseNotesFromMarkdownAndTeamsInFeathers")
 	}
 
 	var r0 []models.ReleaseNote
@@ -114,6 +114,54 @@ func (_m *ReleaseNotesUseCase) GetReleaseNotesFromMDAndTeams(markdown string, te
 	}
 
 	return r0, r1
+}
+
+// ParseReleaseNoteFromMarkdown provides a mock function with given fields: markdown
+func (_m *ReleaseNotesUseCase) ParseReleaseNoteFromMarkdown(markdown string) ([]models.ReleaseNote, error) {
+	ret := _m.Called(markdown)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ParseReleaseNoteFromMarkdown")
+	}
+
+	var r0 []models.ReleaseNote
+	var r1 error
+	if rf, ok := ret.Get(0).(func(string) ([]models.ReleaseNote, error)); ok {
+		return rf(markdown)
+	}
+	if rf, ok := ret.Get(0).(func(string) []models.ReleaseNote); ok {
+		r0 = rf(markdown)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]models.ReleaseNote)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(markdown)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// PopulateTeamsInReleaseNotes provides a mock function with given fields: releaseNotes, teamsInFeathers
+func (_m *ReleaseNotesUseCase) PopulateTeamsInReleaseNotes(releaseNotes []models.ReleaseNote, teamsInFeathers models.Teams) error {
+	ret := _m.Called(releaseNotes, teamsInFeathers)
+
+	if len(ret) == 0 {
+		panic("no return value specified for PopulateTeamsInReleaseNotes")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func([]models.ReleaseNote, models.Teams) error); ok {
+		r0 = rf(releaseNotes, teamsInFeathers)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
 }
 
 // SendReleaseNotes provides a mock function with given fields: subject, notes

--- a/pkg/domain/mocks/ReleaseNotesUseCase.go
+++ b/pkg/domain/mocks/ReleaseNotesUseCase.go
@@ -12,6 +12,26 @@ type ReleaseNotesUseCase struct {
 	mock.Mock
 }
 
+// AppendReleaseNotesToExisting provides a mock function with given fields: existing, new
+func (_m *ReleaseNotesUseCase) AppendReleaseNotesToExisting(existing []models.ReleaseNote, new []models.ReleaseNote) []models.ReleaseNote {
+	ret := _m.Called(existing, new)
+
+	if len(ret) == 0 {
+		panic("no return value specified for AppendReleaseNotesToExisting")
+	}
+
+	var r0 []models.ReleaseNote
+	if rf, ok := ret.Get(0).(func([]models.ReleaseNote, []models.ReleaseNote) []models.ReleaseNote); ok {
+		r0 = rf(existing, new)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]models.ReleaseNote)
+		}
+	}
+
+	return r0
+}
+
 // GenerateBreakdown provides a mock function with given fields: notes, hash, totalTeams
 func (_m *ReleaseNotesUseCase) GenerateBreakdown(notes []models.ReleaseNote, hash string, totalTeams int) (string, error) {
 	ret := _m.Called(notes, hash, totalTeams)

--- a/pkg/domain/releasenotes.go
+++ b/pkg/domain/releasenotes.go
@@ -19,4 +19,7 @@ type ReleaseNotesUseCase interface {
 	GenerateBreakdown(notes []models.ReleaseNote, hash string, totalTeams int) (string, error)
 	// SendReleaseNotes sends release notes to their respective teams
 	SendReleaseNotes(subject string, notes []models.ReleaseNote) error
+	// AppendReleaseNotesToExisting appends new release notes to existing ones if the teams are the same
+	// If the teams are different, then the note isn't appended
+	AppendReleaseNotesToExisting(existing, new []models.ReleaseNote) []models.ReleaseNote
 }

--- a/pkg/domain/releasenotes.go
+++ b/pkg/domain/releasenotes.go
@@ -5,8 +5,12 @@ import (
 )
 
 type ReleaseNotesUseCase interface {
-	// GetReleaseNotesFromMDAndTeams parses release notes from a markdown string attaching the corresponding teams
-	GetReleaseNotesFromMDAndTeams(markdown string, teamsInFeathers models.Teams) ([]models.ReleaseNote, error)
+	// GetReleaseNotesFromMarkdownAndTeamsInFeathers parses release notes from a markdown string attaching the corresponding teams from feathers
+	GetReleaseNotesFromMarkdownAndTeamsInFeathers(markdown string, teamsInFeathers models.Teams) ([]models.ReleaseNote, error)
+	// PopulateTeamsInReleaseNotes populates the teams in the release notes with the corresponding teams in feathers
+	PopulateTeamsInReleaseNotes(releaseNotes []models.ReleaseNote, teamsInFeathers models.Teams) error
+	// ParseReleaseNoteFromMarkdown parses release notes from a markdown string
+	ParseReleaseNoteFromMarkdown(markdown string) ([]models.ReleaseNote, error)
 	// GetMarkdownFromReleaseNotes generates a markdown string from a slice of release notes
 	GetMarkdownFromReleaseNotes(notes []models.ReleaseNote) string
 	// GenerateHash generates a SHA256 hash of the json of a slice of release notes

--- a/pkg/models/releasenotes.go
+++ b/pkg/models/releasenotes.go
@@ -1,6 +1,24 @@
 package models
 
+import "fmt"
+
 type ReleaseNote struct {
 	Teams   Teams
 	Content string
+}
+
+func (r *ReleaseNote) AppendContent(content string) {
+	r.Content += fmt.Sprintf("\n\n---\n\n%s", content)
+}
+
+func (r *ReleaseNote) AreTeamsEqual(other ReleaseNote) bool {
+	if len(r.Teams) != len(other.Teams) {
+		return false
+	}
+	for i, team := range r.Teams {
+		if team.Name != other.Teams[i].Name {
+			return false
+		}
+	}
+	return true
 }

--- a/pkg/releasenotes/usecase/releasenotesuc.go
+++ b/pkg/releasenotes/usecase/releasenotesuc.go
@@ -43,7 +43,29 @@ func NewUseCase(msgClientsHandler domain.MessageHandler) *UseCase {
 	return &UseCase{msgClientsHandler}
 }
 
-func (uc *UseCase) GetReleaseNotesFromMDAndTeams(markdown string, teamsInFeathers models.Teams) ([]models.ReleaseNote, error) {
+func (uc *UseCase) GetReleaseNotesFromMarkdownAndTeamsInFeathers(markdown string, teamsInFeathers models.Teams) ([]models.ReleaseNote, error) {
+	releaseNotes, err := uc.ParseReleaseNoteFromMarkdown(markdown)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get release notes from markdown")
+	}
+	if err = uc.PopulateTeamsInReleaseNotes(releaseNotes, teamsInFeathers); err != nil {
+		return nil, errors.Wrap(err, "failed to populate teams in release notes")
+	}
+	return releaseNotes, nil
+}
+
+func (uc *UseCase) PopulateTeamsInReleaseNotes(releaseNotes []models.ReleaseNote, teamsInFeathers models.Teams) error {
+	for i, note := range releaseNotes {
+		teamsInNote, err := uc.getAndValidateTeamsByNames(note.Teams.GetAllTeamNames(), teamsInFeathers)
+		if err != nil {
+			return errors.Wrap(err, "failed to get teams by name")
+		}
+		releaseNotes[i].Teams = teamsInNote
+	}
+	return nil
+}
+
+func (uc *UseCase) ParseReleaseNoteFromMarkdown(markdown string) ([]models.ReleaseNote, error) {
 	teamNameReg, err := regexp.Compile(teamNameHeaderRegex)
 	if err != nil {
 		return nil, err
@@ -59,16 +81,17 @@ func (uc *UseCase) GetReleaseNotesFromMDAndTeams(markdown string, teamsInFeather
 	// Get the contents for each message & trim to remove any text before the first message
 	contents := teamNameReg.Split(markdown, -1)
 	contents = contents[1:]
-
 	notes := make([]models.ReleaseNote, len(contents))
 	for i, m := range contents {
 		teamsNamesInNote := teamNames[i]
-		teamsInNote, err := uc.getAndValidateTeamsByNames(teamsNamesInNote, teamsInFeathers)
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to get teams by name")
-		}
 		m = uc.removeBotGeneratedText(m)
 		notes[i].Content = strings.TrimSpace(m)
+		teamsInNote := make([]models.Team, 0, len(teamsNamesInNote))
+		for _, teamName := range teamsNamesInNote {
+			teamsInNote = append(teamsInNote, models.Team{
+				Name: teamName,
+			})
+		}
 		notes[i].Teams = teamsInNote
 	}
 	return notes, nil

--- a/pkg/releasenotes/usecase/releasenotesuc_test.go
+++ b/pkg/releasenotes/usecase/releasenotesuc_test.go
@@ -243,7 +243,7 @@ func TestParse(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-			actualMessages, err := uc.GetReleaseNotesFromMDAndTeams(tt.inputMarkdown, allTeams)
+			actualMessages, err := uc.GetReleaseNotesFromMarkdownAndTeamsInFeathers(tt.inputMarkdown, allTeams)
 			if tt.shouldError {
 				fmt.Println("expected error: " + err.Error())
 				assert.Error(t, err)

--- a/pkg/webhook/usecase/webhookuc.go
+++ b/pkg/webhook/usecase/webhookuc.go
@@ -64,7 +64,7 @@ func (w *WebHookUseCase) ValidatePeacock(e *models.PullRequestEventDTO) error {
 		return w.handleError(ctx, domain.ValidationContext, e, err)
 	}
 
-	releaseNotes, err := w.notesUC.GetReleaseNotesFromMDAndTeams(e.Body, feathers.Teams)
+	releaseNotes, err := w.notesUC.GetReleaseNotesFromMarkdownAndTeamsInFeathers(e.Body, feathers.Teams)
 	if err != nil {
 		return w.handleError(ctx, domain.ValidationContext, e, errors.Wrap(err, "failed to parse release notes from markdown"))
 	}
@@ -146,7 +146,7 @@ func (w *WebHookUseCase) RunPeacock(e *models.PullRequestEventDTO) error {
 	}
 
 	// Parse the PR body for any releaseNotes
-	releaseNotes, err := w.notesUC.GetReleaseNotesFromMDAndTeams(e.Body, feathers.Teams)
+	releaseNotes, err := w.notesUC.GetReleaseNotesFromMarkdownAndTeamsInFeathers(e.Body, feathers.Teams)
 	if err != nil {
 		return w.handleError(ctx, domain.ReleaseContext, e, errors.Wrap(err, "failed to parse release notes from markdown"))
 	}

--- a/pkg/webhook/usecase/webhookuc_test.go
+++ b/pkg/webhook/usecase/webhookuc_test.go
@@ -105,7 +105,7 @@ func TestWebHookUseCase_ValidatePeacock(t *testing.T) {
 		mockSCM.On("CommentOnPR", mockCTX, mockEvent.RepoOwner, mockEvent.RepoName, mockEvent.PRNumber, mock.Anything).Return(nil).Once()
 		mockSCM.On("CreatePeacockCommitStatus", mockCTX, mockEvent.RepoOwner, mockEvent.RepoName, mockEvent.SHA, domain.SuccessState, domain.ValidationContext).Return(nil).Once()
 
-		mockNotesUC.On("GetReleaseNotesFromMDAndTeams", prBody, allTeams).Return(mockNotes, nil)
+		mockNotesUC.On("GetReleaseNotesFromMarkdownAndTeamsInFeathers", prBody, allTeams).Return(mockNotes, nil)
 		mockNotesUC.On("GenerateHash", mockNotes).Return(mockHash, nil)
 		mockNotesUC.On("GenerateBreakdown", mockNotes, mockHash, 2).Return("", nil)
 
@@ -142,7 +142,7 @@ func TestWebHookUseCase_RunPeacock(t *testing.T) {
 		mockSCM.On("CreatePeacockCommitStatus", mockCTX, mockEvent.RepoOwner, mockEvent.RepoName, defaultSHA, domain.SuccessState, domain.ReleaseContext).Return(nil).Once()
 		mockSCM.On("GetFilesChangedFromPR", mockCTX, mockEvent.RepoOwner, mockEvent.RepoName, mockEvent.PRNumber).Return(mockFilesChanged, nil).Once()
 
-		mockNotesUC.On("GetReleaseNotesFromMDAndTeams", prBody, allTeams).Return(mockNotes, nil)
+		mockNotesUC.On("GetReleaseNotesFromMarkdownAndTeamsInFeathers", prBody, allTeams).Return(mockNotes, nil)
 		mockNotesUC.On("SendReleaseNotes", mockFeathers.Config.Messages.Subject, mockNotes).Return(nil)
 
 		mockReleaseUC.On("SaveRelease", mockCTX, "staging", mockNotes, mockPullRequestEventDTO.Summary()).Return(nil).Once()


### PR DESCRIPTION
### Changes
* Split out the release notes parsing logic into separate functions
* Add the ability to merge release notes if the teams are the same

### Context
For Architect to append release notes Peacock needs to be able to merge the notes into one communication.

Example:
```
### Notify TestWebhook1
Some fun stuff!

### Notify TestWebhook1
More fun stuff :)
```
At the point of sending becomes:
```
Some fun stuff!

---

More fun stuff :)
```

![image](https://github.com/user-attachments/assets/b9569e18-69c3-4c12-8755-1e5f85f64d0e)
