### PR TITLE
feat: expose function for merging new notes into existing markdown

### DIFF
--- a/pkg/domain/mocks/ReleaseNotesUseCase.go
+++ b/pkg/domain/mocks/ReleaseNotesUseCase.go
@@ -12,24 +12,32 @@ type ReleaseNotesUseCase struct {
 	mock.Mock
 }
 
-// AppendReleaseNotesToExisting provides a mock function with given fields: existing, new
-func (_m *ReleaseNotesUseCase) AppendReleaseNotesToExisting(existing []models.ReleaseNote, new []models.ReleaseNote) []models.ReleaseNote {
-	ret := _m.Called(existing, new)
+// AppendReleaseNotesToExistingMarkdown provides a mock function with given fields: existingMarkdown, releaseNotesToAppend
+func (_m *ReleaseNotesUseCase) AppendReleaseNotesToExistingMarkdown(existingMarkdown string, releaseNotesToAppend []models.ReleaseNote) (string, error) {
+	ret := _m.Called(existingMarkdown, releaseNotesToAppend)
 
 	if len(ret) == 0 {
-		panic("no return value specified for AppendReleaseNotesToExisting")
+		panic("no return value specified for AppendReleaseNotesToExistingMarkdown")
 	}
 
-	var r0 []models.ReleaseNote
-	if rf, ok := ret.Get(0).(func([]models.ReleaseNote, []models.ReleaseNote) []models.ReleaseNote); ok {
-		r0 = rf(existing, new)
+	var r0 string
+	var r1 error
+	if rf, ok := ret.Get(0).(func(string, []models.ReleaseNote) (string, error)); ok {
+		return rf(existingMarkdown, releaseNotesToAppend)
+	}
+	if rf, ok := ret.Get(0).(func(string, []models.ReleaseNote) string); ok {
+		r0 = rf(existingMarkdown, releaseNotesToAppend)
 	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]models.ReleaseNote)
-		}
+		r0 = ret.Get(0).(string)
 	}
 
-	return r0
+	if rf, ok := ret.Get(1).(func(string, []models.ReleaseNote) error); ok {
+		r1 = rf(existingMarkdown, releaseNotesToAppend)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // GenerateBreakdown provides a mock function with given fields: notes, hash, totalTeams
@@ -136,34 +144,41 @@ func (_m *ReleaseNotesUseCase) GetReleaseNotesFromMarkdownAndTeamsInFeathers(mar
 	return r0, r1
 }
 
-// ParseReleaseNoteFromMarkdown provides a mock function with given fields: markdown
-func (_m *ReleaseNotesUseCase) ParseReleaseNoteFromMarkdown(markdown string) ([]models.ReleaseNote, error) {
-	ret := _m.Called(markdown)
+// ParseReleaseNoteFromMarkdown provides a mock function with given fields: markdown, sanitise
+func (_m *ReleaseNotesUseCase) ParseReleaseNoteFromMarkdown(markdown string, sanitise bool) (string, []models.ReleaseNote, error) {
+	ret := _m.Called(markdown, sanitise)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ParseReleaseNoteFromMarkdown")
 	}
 
-	var r0 []models.ReleaseNote
-	var r1 error
-	if rf, ok := ret.Get(0).(func(string) ([]models.ReleaseNote, error)); ok {
-		return rf(markdown)
+	var r0 string
+	var r1 []models.ReleaseNote
+	var r2 error
+	if rf, ok := ret.Get(0).(func(string, bool) (string, []models.ReleaseNote, error)); ok {
+		return rf(markdown, sanitise)
 	}
-	if rf, ok := ret.Get(0).(func(string) []models.ReleaseNote); ok {
-		r0 = rf(markdown)
+	if rf, ok := ret.Get(0).(func(string, bool) string); ok {
+		r0 = rf(markdown, sanitise)
 	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]models.ReleaseNote)
+		r0 = ret.Get(0).(string)
+	}
+
+	if rf, ok := ret.Get(1).(func(string, bool) []models.ReleaseNote); ok {
+		r1 = rf(markdown, sanitise)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).([]models.ReleaseNote)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(string) error); ok {
-		r1 = rf(markdown)
+	if rf, ok := ret.Get(2).(func(string, bool) error); ok {
+		r2 = rf(markdown, sanitise)
 	} else {
-		r1 = ret.Error(1)
+		r2 = ret.Error(2)
 	}
 
-	return r0, r1
+	return r0, r1, r2
 }
 
 // PopulateTeamsInReleaseNotes provides a mock function with given fields: releaseNotes, teamsInFeathers

--- a/pkg/domain/releasenotes.go
+++ b/pkg/domain/releasenotes.go
@@ -10,7 +10,7 @@ type ReleaseNotesUseCase interface {
 	// PopulateTeamsInReleaseNotes populates the teams in the release notes with the corresponding teams in feathers
 	PopulateTeamsInReleaseNotes(releaseNotes []models.ReleaseNote, teamsInFeathers models.Teams) error
 	// ParseReleaseNoteFromMarkdown parses release notes from a markdown string
-	ParseReleaseNoteFromMarkdown(markdown string) ([]models.ReleaseNote, error)
+	ParseReleaseNoteFromMarkdown(markdown string, sanitise bool) (preamble string, notes []models.ReleaseNote, err error)
 	// GetMarkdownFromReleaseNotes generates a markdown string from a slice of release notes
 	GetMarkdownFromReleaseNotes(notes []models.ReleaseNote) string
 	// GenerateHash generates a SHA256 hash of the json of a slice of release notes
@@ -19,7 +19,7 @@ type ReleaseNotesUseCase interface {
 	GenerateBreakdown(notes []models.ReleaseNote, hash string, totalTeams int) (string, error)
 	// SendReleaseNotes sends release notes to their respective teams
 	SendReleaseNotes(subject string, notes []models.ReleaseNote) error
-	// AppendReleaseNotesToExisting appends new release notes to existing ones if the teams are the same
-	// If the teams are different, then the note isn't appended
-	AppendReleaseNotesToExisting(existing, new []models.ReleaseNote) []models.ReleaseNote
+	// AppendReleaseNotesToExistingMarkdown appends release notes to an existing markdown string merging notes by team if possible.
+	// If a note is not mergable, it will be appended as a new note. Order of the existing notes is preserved.
+	AppendReleaseNotesToExistingMarkdown(existingMarkdown string, releaseNotesToAppend []models.ReleaseNote) (string, error)
 }

--- a/pkg/models/releasenotes.go
+++ b/pkg/models/releasenotes.go
@@ -8,7 +8,7 @@ type ReleaseNote struct {
 }
 
 func (r *ReleaseNote) AppendContent(content string) {
-	r.Content += fmt.Sprintf("\n\n---\n\n%s", content)
+	r.Content += fmt.Sprintf("\n---\n%s", content)
 }
 
 func (r *ReleaseNote) AreTeamsEqual(other ReleaseNote) bool {

--- a/pkg/releasenotes/usecase/releasenotesuc.go
+++ b/pkg/releasenotes/usecase/releasenotesuc.go
@@ -115,9 +115,8 @@ func (uc *UseCase) MergeReleaseNotes(notes []models.ReleaseNote) []models.Releas
 		return nil
 	}
 
-	// Merge the release notes by teams
-	merged := make([]models.ReleaseNote, 0, len(notes))
 	teamsMap := make(map[string]models.ReleaseNote)
+	order := make([]string, 0, len(notes))
 
 	for _, note := range notes {
 		teamNames := utils.CommaSeparated(note.Teams.GetAllTeamNames())
@@ -126,11 +125,13 @@ func (uc *UseCase) MergeReleaseNotes(notes []models.ReleaseNote) []models.Releas
 			teamsMap[teamNames] = existingNote
 		} else {
 			teamsMap[teamNames] = note
+			order = append(order, teamNames)
 		}
 	}
 
-	for _, note := range teamsMap {
-		merged = append(merged, note)
+	merged := make([]models.ReleaseNote, 0, len(order))
+	for _, teamNames := range order {
+		merged = append(merged, teamsMap[teamNames])
 	}
 	return merged
 }

--- a/pkg/releasenotes/usecase/releasenotesuc.go
+++ b/pkg/releasenotes/usecase/releasenotesuc.go
@@ -75,7 +75,7 @@ func (uc *UseCase) ParseReleaseNoteFromMarkdown(markdown string, sanitise bool) 
 	log.Debug("Parsing release notes from markdown")
 	teamNames := uc.parseTeamNames(teamNameReg, markdown)
 	if len(teamNames) < 1 {
-		return "", nil, nil
+		return markdown, nil, nil
 	}
 	log.Debugf("%d notes found in markdown", len(teamNames))
 
@@ -141,7 +141,7 @@ func (uc *UseCase) AppendReleaseNotesToExistingMarkdown(existingMarkdown string,
 	if err != nil {
 		return "", errors.Wrap(err, "failed to parse existing markdown")
 	}
-
+	preamble = addSuffixIfNotExists(preamble, "\n\n")
 	mergedReleaseNotes := uc.mergeOrAppendReleaseNotes(existingReleaseNotes, releaseNotesToAppend)
 	return preamble + uc.GetMarkdownFromReleaseNotes(mergedReleaseNotes), nil
 }
@@ -263,4 +263,11 @@ func (uc *UseCase) GenerateBreakdown(notes []models.ReleaseNote, hash string, to
 
 func (uc *UseCase) SendReleaseNotes(subject string, notes []models.ReleaseNote) error {
 	return uc.MsgClientsHandler.SendReleaseNotes(subject, notes)
+}
+
+func addSuffixIfNotExists(text string, suffix string) string {
+	if text == "" || strings.HasSuffix(text, suffix) {
+		return text
+	}
+	return text + suffix
 }

--- a/pkg/releasenotes/usecase/releasenotesuc.go
+++ b/pkg/releasenotes/usecase/releasenotesuc.go
@@ -44,7 +44,7 @@ func NewUseCase(msgClientsHandler domain.MessageHandler) *UseCase {
 }
 
 func (uc *UseCase) GetReleaseNotesFromMarkdownAndTeamsInFeathers(markdown string, teamsInFeathers models.Teams) ([]models.ReleaseNote, error) {
-	releaseNotes, err := uc.ParseReleaseNoteFromMarkdown(markdown)
+	_, releaseNotes, err := uc.ParseReleaseNoteFromMarkdown(markdown, true)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get release notes from markdown")
 	}
@@ -66,26 +66,30 @@ func (uc *UseCase) PopulateTeamsInReleaseNotes(releaseNotes []models.ReleaseNote
 	return nil
 }
 
-func (uc *UseCase) ParseReleaseNoteFromMarkdown(markdown string) ([]models.ReleaseNote, error) {
+func (uc *UseCase) ParseReleaseNoteFromMarkdown(markdown string, sanitise bool) (preamble string, notes []models.ReleaseNote, err error) {
 	teamNameReg, err := regexp.Compile(teamNameHeaderRegex)
 	if err != nil {
-		return nil, err
+		return "", nil, err
 	}
 
 	log.Debug("Parsing release notes from markdown")
 	teamNames := uc.parseTeamNames(teamNameReg, markdown)
 	if len(teamNames) < 1 {
-		return nil, nil
+		return "", nil, nil
 	}
 	log.Debugf("%d notes found in markdown", len(teamNames))
 
 	// Get the contents for each message & trim to remove any text before the first message
-	contents := teamNameReg.Split(markdown, -1)
-	contents = contents[1:]
-	notes := make([]models.ReleaseNote, len(contents))
-	for i, m := range contents {
+	markdownSplit := teamNameReg.Split(markdown, -1)
+	preamble = markdownSplit[0]
+	markdownSplit = markdownSplit[1:]
+
+	notes = make([]models.ReleaseNote, len(markdownSplit))
+	for i, m := range markdownSplit {
 		teamsNamesInNote := teamNames[i]
-		m = uc.removeBotGeneratedText(m)
+		if sanitise {
+			m = uc.removeBotGeneratedText(m)
+		}
 		notes[i].Content = strings.TrimSpace(m)
 		teamsInNote := make([]models.Team, 0, len(teamsNamesInNote))
 		for _, teamName := range teamsNamesInNote {
@@ -95,7 +99,7 @@ func (uc *UseCase) ParseReleaseNoteFromMarkdown(markdown string) ([]models.Relea
 		}
 		notes[i].Teams = teamsInNote
 	}
-	return notes, nil
+	return preamble, notes, nil
 }
 
 func (uc *UseCase) GetMarkdownFromReleaseNotes(notes []models.ReleaseNote) string {
@@ -131,20 +135,47 @@ func (uc *UseCase) MergeReleaseNotes(notes []models.ReleaseNote) []models.Releas
 	return merged
 }
 
-func (uc *UseCase) AppendReleaseNotesToExisting(existing, new []models.ReleaseNote) []models.ReleaseNote {
-	out := make([]models.ReleaseNote, len(existing))
-	copy(out, existing)
+func (uc *UseCase) AppendReleaseNotesToExistingMarkdown(existingMarkdown string, releaseNotesToAppend []models.ReleaseNote) (string, error) {
+	// Parse the existing markdown to get the release notes
+	preamble, existingReleaseNotes, err := uc.ParseReleaseNoteFromMarkdown(existingMarkdown, false)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to parse existing markdown")
+	}
 
-	for i, existingNote := range existing {
-		for _, newNote := range new {
-			if existingNote.AreTeamsEqual(newNote) {
-				// Append content if teams match
-				out[i].AppendContent(newNote.Content)
-				break
-			}
+	mergedReleaseNotes := uc.mergeOrAppendReleaseNotes(existingReleaseNotes, releaseNotesToAppend)
+	return preamble + uc.GetMarkdownFromReleaseNotes(mergedReleaseNotes), nil
+}
+
+// mergeOrAppendReleaseNotes merges or appends release notes based on the teams maintaining the original order
+func (uc *UseCase) mergeOrAppendReleaseNotes(existing, new []models.ReleaseNote) []models.ReleaseNote {
+	// Create a map to store the merged release notes and an array to maintain the order
+	merged := make(map[string]models.ReleaseNote)
+	order := make([]string, 0, len(existing))
+
+	// Iterate over the existing release notes and add them to the map by the teams in the note
+	for _, note := range existing {
+		teams := utils.CommaSeparated(note.Teams.GetAllTeamNames())
+		merged[teams] = note
+		order = append(order, teams)
+	}
+
+	// Iterate over the new release notes and merge or append them
+	for _, note := range new {
+		teams := utils.CommaSeparated(note.Teams.GetAllTeamNames())
+		if existingNote, ok := merged[teams]; ok {
+			existingNote.AppendContent(note.Content)
+			merged[teams] = existingNote
+		} else {
+			merged[teams] = note
+			order = append(order, teams)
 		}
 	}
-	return out
+
+	result := make([]models.ReleaseNote, 0, len(order))
+	for _, key := range order {
+		result = append(result, merged[key])
+	}
+	return result
 }
 
 var (

--- a/pkg/releasenotes/usecase/releasenotesuc_test.go
+++ b/pkg/releasenotes/usecase/releasenotesuc_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spring-financial-group/peacock/pkg/msgclients/webhook"
 	"github.com/spring-financial-group/peacock/pkg/releasenotes/delivery/msgclients"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"testing"
 )
 
@@ -276,14 +277,17 @@ func TestUseCase_ParseReleaseNoteFromMarkdown(t *testing.T) {
 	})
 
 	testCases := []struct {
-		name          string
-		inputMarkdown string
-		expectedNotes []models.ReleaseNote
-		shouldError   bool
+		name             string
+		inputMarkdown    string
+		expectedNotes    []models.ReleaseNote
+		expectedPreamble string
+		sanitise         bool
+		shouldError      bool
 	}{
 		{
-			name:          "Passing",
-			inputMarkdown: "### Notify infrastructure, devs\nTest Content\n### Notify ml\nMore Test Content",
+			name:             "Passing",
+			inputMarkdown:    "### Notify infrastructure, devs\nTest Content\n### Notify ml\nMore Test Content",
+			expectedPreamble: "",
 			expectedNotes: []models.ReleaseNote{
 				{
 					Teams:   models.Teams{{Name: "infrastructure"}, {Name: "devs"}},
@@ -294,19 +298,54 @@ func TestUseCase_ParseReleaseNoteFromMarkdown(t *testing.T) {
 					Content: "More Test Content",
 				},
 			},
+			sanitise:    true,
 			shouldError: false,
+		},
+		{
+			name:             "WithPreamble",
+			inputMarkdown:    "This is some preamble that exists outside of the notes\n\n### Notify infrastructure, devs\nTest Content\n### Notify ml\nMore Test Content",
+			expectedPreamble: "This is some preamble that exists outside of the notes\n\n",
+			expectedNotes: []models.ReleaseNote{
+				{
+					Teams:   models.Teams{{Name: "infrastructure"}, {Name: "devs"}},
+					Content: "Test Content",
+				},
+				{
+					Teams:   models.Teams{{Name: "ml"}},
+					Content: "More Test Content",
+				},
+			},
+			sanitise:    true,
+			shouldError: false,
+		},
+		{
+			name:             "RemoveBotGeneratedText",
+			inputMarkdown:    "### Notify infrastructure\n[//]: # (beaver-start)\nTest Content\n\n[//]: # (some-bot-content)\nAnother bit of content\n### Notify devs\nMore Test Content",
+			expectedPreamble: "",
+			expectedNotes: []models.ReleaseNote{
+				{
+					Teams:   models.Teams{{Name: "infrastructure"}},
+					Content: "Test Content\n\nAnother bit of content",
+				},
+				{
+					Teams:   models.Teams{{Name: "devs"}},
+					Content: "More Test Content",
+				},
+			},
+			sanitise: true,
 		},
 	}
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-			actualMessages, err := uc.ParseReleaseNoteFromMarkdown(tt.inputMarkdown)
+			actualPreamble, actualMessages, err := uc.ParseReleaseNoteFromMarkdown(tt.inputMarkdown, tt.sanitise)
 			if tt.shouldError {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
 			}
 			assert.Equal(t, tt.expectedNotes, actualMessages)
+			assert.Equal(t, tt.expectedPreamble, actualPreamble)
 		})
 	}
 }
@@ -409,46 +448,38 @@ func TestUseCase_GetMarkdownFromReleaseNotes(t *testing.T) {
 	}
 }
 
-func TestUseCase_AppendReleaseNotesToExisting(t *testing.T) {
+func TestUseCase_AppendReleaseNotesToExistingMarkdown(t *testing.T) {
 	testCases := []struct {
-		name     string
-		existing []models.ReleaseNote
-		new      []models.ReleaseNote
-		expected []models.ReleaseNote
+		name             string
+		existingMarkdown string
+		new              []models.ReleaseNote
+		expected         string
 	}{
 		{
-			name: "SingleNote",
-			existing: []models.ReleaseNote{
-				{
-					Teams:   models.Teams{infraTeam},
-					Content: "Existing note content",
-				},
-			},
+			name:             "SingleNoteMerged",
+			existingMarkdown: "### Notify infrastructure\nExisting note content",
 			new: []models.ReleaseNote{
 				{
 					Teams:   models.Teams{infraTeam},
-					Content: "New note content",
+					Content: "More note content",
 				},
 			},
-			expected: []models.ReleaseNote{
-				{
-					Teams:   models.Teams{infraTeam},
-					Content: "Existing note content\n\n---\n\nNew note content",
-				},
-			},
+			expected: "### Notify infrastructure\nExisting note content\n\n---\n\nMore note content",
 		},
 		{
-			name: "MultipleNotes",
-			existing: []models.ReleaseNote{
+			name:             "SingleNoteAppended",
+			existingMarkdown: "### Notify ml\nExisting note content",
+			new: []models.ReleaseNote{
 				{
 					Teams:   models.Teams{infraTeam},
-					Content: "Existing note content",
-				},
-				{
-					Teams:   models.Teams{mlTeam},
-					Content: "Another existing note content",
+					Content: "More note content",
 				},
 			},
+			expected: "### Notify ml\nExisting note content\n\n### Notify infrastructure\nMore note content",
+		},
+		{
+			name:             "MultipleNotes",
+			existingMarkdown: "### Notify infrastructure\nExisting note content\n### Notify ml\nAnother existing note content",
 			new: []models.ReleaseNote{
 				{
 					Teams:   models.Teams{infraTeam},
@@ -459,51 +490,44 @@ func TestUseCase_AppendReleaseNotesToExisting(t *testing.T) {
 					Content: "Another new note content",
 				},
 			},
-			expected: []models.ReleaseNote{
-				{
-					Teams:   models.Teams{infraTeam},
-					Content: "Existing note content\n\n---\n\nNew note content",
-				},
-				{
-					Teams:   models.Teams{mlTeam},
-					Content: "Another existing note content\n\n---\n\nAnother new note content",
-				},
-			},
+			expected: "### Notify infrastructure\nExisting note content\n\n---\n\nNew note content\n\n### Notify ml\nAnother existing note content\n\n---\n\nAnother new note content",
 		},
 		{
-			name: "UnModifiedExistingNotes",
-			existing: []models.ReleaseNote{
+			name:             "MergingAndAppendingAndMaintainingOrder",
+			existingMarkdown: "### Notify infrastructure\nExisting note content\n### Notify ml\nAnother existing note content",
+			new: []models.ReleaseNote{
 				{
 					Teams:   models.Teams{infraTeam},
-					Content: "Existing note content",
+					Content: "New note content",
 				},
 				{
 					Teams:   models.Teams{mlTeam},
-					Content: "Another existing note content",
+					Content: "Another new note content",
+				},
+				{
+					Teams:   models.Teams{productTeam},
+					Content: "Product note content",
 				},
 			},
+			expected: "### Notify infrastructure\nExisting note content\n\n---\n\nNew note content\n\n### Notify ml\nAnother existing note content\n\n---\n\nAnother new note content\n\n### Notify product\nProduct note content",
+		},
+		{
+			name:             "BotTextNotRemoved",
+			existingMarkdown: "### Notify infrastructure\nExisting note content\n[//]: # (bot-start)\nExisting bot content\n\n[//]: # (bot-stop)",
 			new: []models.ReleaseNote{
 				{
 					Teams:   models.Teams{infraTeam},
 					Content: "New note content",
 				},
 			},
-			expected: []models.ReleaseNote{
-				{
-					Teams:   models.Teams{infraTeam},
-					Content: "Existing note content\n\n---\n\nNew note content",
-				},
-				{
-					Teams:   models.Teams{mlTeam},
-					Content: "Another existing note content",
-				},
-			},
+			expected: "### Notify infrastructure\nExisting note content\n[//]: # (bot-start)\nExisting bot content\n\n[//]: # (bot-stop)\n\n---\n\nNew note content",
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			uc := NewUseCase(nil)
-			actual := uc.AppendReleaseNotesToExisting(tc.existing, tc.new)
+			actual, err := uc.AppendReleaseNotesToExistingMarkdown(tc.existingMarkdown, tc.new)
+			require.NoError(t, err)
 			assert.Equal(t, tc.expected, actual)
 		})
 	}

--- a/pkg/releasenotes/usecase/releasenotesuc_test.go
+++ b/pkg/releasenotes/usecase/releasenotesuc_test.go
@@ -246,7 +246,7 @@ func TestUseCase_GetReleaseNotesFromMarkdownAndTeamsInFeathers(t *testing.T) {
 			expectedNotes: []models.ReleaseNote{
 				{
 					Teams:   models.Teams{infraTeam},
-					Content: "Test Content\n\n---\n\nMore Test Content",
+					Content: "Test Content\n---\nMore Test Content",
 				},
 				{
 					Teams:   models.Teams{devsTeam, infraTeam},
@@ -464,7 +464,7 @@ func TestUseCase_AppendReleaseNotesToExistingMarkdown(t *testing.T) {
 					Content: "More note content",
 				},
 			},
-			expected: "### Notify infrastructure\nExisting note content\n\n---\n\nMore note content",
+			expected: "### Notify infrastructure\nExisting note content\n---\nMore note content",
 		},
 		{
 			name:             "SingleNoteAppended",
@@ -490,7 +490,7 @@ func TestUseCase_AppendReleaseNotesToExistingMarkdown(t *testing.T) {
 					Content: "Another new note content",
 				},
 			},
-			expected: "### Notify infrastructure\nExisting note content\n\n---\n\nNew note content\n\n### Notify ml\nAnother existing note content\n\n---\n\nAnother new note content",
+			expected: "### Notify infrastructure\nExisting note content\n---\nNew note content\n\n### Notify ml\nAnother existing note content\n---\nAnother new note content",
 		},
 		{
 			name:             "MergingAndAppendingAndMaintainingOrder",
@@ -509,7 +509,7 @@ func TestUseCase_AppendReleaseNotesToExistingMarkdown(t *testing.T) {
 					Content: "Product note content",
 				},
 			},
-			expected: "### Notify infrastructure\nExisting note content\n\n---\n\nNew note content\n\n### Notify ml\nAnother existing note content\n\n---\n\nAnother new note content\n\n### Notify product\nProduct note content",
+			expected: "### Notify infrastructure\nExisting note content\n---\nNew note content\n\n### Notify ml\nAnother existing note content\n---\nAnother new note content\n\n### Notify product\nProduct note content",
 		},
 		{
 			name:             "BotTextNotRemoved",
@@ -520,7 +520,7 @@ func TestUseCase_AppendReleaseNotesToExistingMarkdown(t *testing.T) {
 					Content: "New note content",
 				},
 			},
-			expected: "### Notify infrastructure\nExisting note content\n[//]: # (bot-start)\nExisting bot content\n\n[//]: # (bot-stop)\n\n---\n\nNew note content",
+			expected: "### Notify infrastructure\nExisting note content\n[//]: # (bot-start)\nExisting bot content\n\n[//]: # (bot-stop)\n---\nNew note content",
 		},
 		{
 			name:             "NoExistingReleaseNotes",

--- a/pkg/releasenotes/usecase/releasenotesuc_test.go
+++ b/pkg/releasenotes/usecase/releasenotesuc_test.go
@@ -522,6 +522,28 @@ func TestUseCase_AppendReleaseNotesToExistingMarkdown(t *testing.T) {
 			},
 			expected: "### Notify infrastructure\nExisting note content\n[//]: # (bot-start)\nExisting bot content\n\n[//]: # (bot-stop)\n\n---\n\nNew note content",
 		},
+		{
+			name:             "NoExistingReleaseNotes",
+			existingMarkdown: "Some text that isn't a note",
+			new: []models.ReleaseNote{
+				{
+					Teams:   models.Teams{infraTeam},
+					Content: "New note content",
+				},
+			},
+			expected: "Some text that isn't a note\n\n### Notify infrastructure\nNew note content",
+		},
+		{
+			name:             "NoExistingMarkdown",
+			existingMarkdown: "",
+			new: []models.ReleaseNote{
+				{
+					Teams:   models.Teams{infraTeam},
+					Content: "New note content",
+				},
+			},
+			expected: "### Notify infrastructure\nNew note content",
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
### Changes
* Add function for appending new releasenotes to existing markdown
  * This maintains the original order of the existing markdown notes
  * Doesn't remove bot generated text
* Reduce the spacing between merged notes for brevity (`\n\n---\n\n` -> `\n---\n`)
* Preserve the ordering of merged notes

### Context
Will be neater on the downstream PRs if the notes are already merged, rather than having multiple instances of messages to different teams

### Example
Before:
```
Some preamble text that doesn't matter to the release notes

### Notify Client
Some really cool releasenotes for our clients

### Notify Client
Some more lovely release notes that have been appended to the description
```

Now:
```
Some preamble text that doesn't matter to the release notes

### Notify Client
Some really cool releasenotes for our clients.
They're gonna love this feature.
---
Some more lovely release notes that have been appended to the description.
They will really appreciated the merging of release notes.
```