### PR TITLE
feat: don't send notes that are equal to the PR template

### DIFF
--- a/.peacock/feathers.yaml
+++ b/.peacock/feathers.yaml
@@ -1,3 +1,6 @@
+config:
+  prBodyTemplatePath: docs/peacock_pull_request_template.md
+
 teams:
   - name: TestWebhook1
     apiKey: MockAPIKey1

--- a/docs/peacock_pull_request_template.md
+++ b/docs/peacock_pull_request_template.md
@@ -1,8 +1,8 @@
-### Notify TeamName1, TeamName2
+### Notify TestWebhook1, TestWebhook2
 Message Content
 
-### Notify TeamName2
+### Notify TestWebhook2
 Other message content
 
-### Notify TeamName3
+### Notify TestSlack1
 Other more different message content

--- a/pkg/domain/mocks/ReleaseNotesUseCase.go
+++ b/pkg/domain/mocks/ReleaseNotesUseCase.go
@@ -40,6 +40,26 @@ func (_m *ReleaseNotesUseCase) AppendReleaseNotesToExistingMarkdown(existingMark
 	return r0, r1
 }
 
+// FindEqualReleaseNotes provides a mock function with given fields: a, b
+func (_m *ReleaseNotesUseCase) FindEqualReleaseNotes(a []models.ReleaseNote, b []models.ReleaseNote) [][2]int {
+	ret := _m.Called(a, b)
+
+	if len(ret) == 0 {
+		panic("no return value specified for FindEqualReleaseNotes")
+	}
+
+	var r0 [][2]int
+	if rf, ok := ret.Get(0).(func([]models.ReleaseNote, []models.ReleaseNote) [][2]int); ok {
+		r0 = rf(a, b)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([][2]int)
+		}
+	}
+
+	return r0
+}
+
 // GenerateBreakdown provides a mock function with given fields: notes, hash, totalTeams
 func (_m *ReleaseNotesUseCase) GenerateBreakdown(notes []models.ReleaseNote, hash string, totalTeams int) (string, error) {
 	ret := _m.Called(notes, hash, totalTeams)

--- a/pkg/domain/releasenotes.go
+++ b/pkg/domain/releasenotes.go
@@ -22,4 +22,7 @@ type ReleaseNotesUseCase interface {
 	// AppendReleaseNotesToExistingMarkdown appends release notes to an existing markdown string merging notes by team if possible.
 	// If a note is not mergable, it will be appended as a new note. Order of the existing notes is preserved.
 	AppendReleaseNotesToExistingMarkdown(existingMarkdown string, releaseNotesToAppend []models.ReleaseNote) (string, error)
+	// FindEqualReleaseNotes compares each release note in slice 'a' with each note in slice 'b'.
+	// It returns a slice of index pairs [i, j] where the notes have equal teams and content.
+	FindEqualReleaseNotes(a, b []models.ReleaseNote) [][2]int
 }

--- a/pkg/models/feathers.go
+++ b/pkg/models/feathers.go
@@ -6,7 +6,8 @@ type Feathers struct {
 }
 
 type Config struct {
-	Messages Messages `yaml:"messages"`
+	Messages           Messages `yaml:"messages"`
+	PRBodyTemplatePath string   `yaml:"prBodyTemplatePath"`
 }
 
 type Messages struct {

--- a/pkg/releasenotes/usecase/releasenotesuc.go
+++ b/pkg/releasenotes/usecase/releasenotesuc.go
@@ -266,6 +266,18 @@ func (uc *UseCase) SendReleaseNotes(subject string, notes []models.ReleaseNote) 
 	return uc.MsgClientsHandler.SendReleaseNotes(subject, notes)
 }
 
+func (uc *UseCase) FindEqualReleaseNotes(a, b []models.ReleaseNote) [][2]int {
+	equalPairs := make([][2]int, 0)
+	for i, noteA := range a {
+		for j, noteB := range b {
+			if noteA.AreTeamsEqual(noteB) && noteA.Content == noteB.Content {
+				equalPairs = append(equalPairs, [2]int{i, j})
+			}
+		}
+	}
+	return equalPairs
+}
+
 func addSuffixIfNotExists(text string, suffix string) string {
 	if text == "" || strings.HasSuffix(text, suffix) {
 		return text

--- a/pkg/releasenotes/usecase/releasenotesuc_test.go
+++ b/pkg/releasenotes/usecase/releasenotesuc_test.go
@@ -554,3 +554,52 @@ func TestUseCase_AppendReleaseNotesToExistingMarkdown(t *testing.T) {
 		})
 	}
 }
+
+func TestUseCase_FindEqualReleaseNotes(t *testing.T) {
+	uc := NewUseCase(nil)
+
+	teamA := models.Team{Name: "A"}
+	teamB := models.Team{Name: "B"}
+
+	note := func(teams []models.Team, content string) models.ReleaseNote {
+		return models.ReleaseNote{Teams: teams, Content: content}
+	}
+
+	tests := []struct {
+		name string
+		a, b []models.ReleaseNote
+		want [][2]int
+	}{
+		{
+			name: "No matches",
+			a:    []models.ReleaseNote{note([]models.Team{teamA}, "foo")},
+			b:    []models.ReleaseNote{note([]models.Team{teamB}, "bar")},
+			want: [][2]int{},
+		},
+		{
+			name: "One match",
+			a:    []models.ReleaseNote{note([]models.Team{teamA}, "foo")},
+			b:    []models.ReleaseNote{note([]models.Team{teamA}, "foo")},
+			want: [][2]int{{0, 0}},
+		},
+		{
+			name: "Multiple matches",
+			a:    []models.ReleaseNote{note([]models.Team{teamA}, "foo"), note([]models.Team{teamB}, "bar")},
+			b:    []models.ReleaseNote{note([]models.Team{teamA}, "foo"), note([]models.Team{teamB}, "bar")},
+			want: [][2]int{{0, 0}, {1, 1}},
+		},
+		{
+			name: "Duplicate content, different teams",
+			a:    []models.ReleaseNote{note([]models.Team{teamA}, "foo")},
+			b:    []models.ReleaseNote{note([]models.Team{teamB}, "foo")},
+			want: [][2]int{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := uc.FindEqualReleaseNotes(tt.a, tt.b)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
### Notify TestWebhook1, TestWebhook2
Message Content

### Notify TestWebhook2
Other message content

### Notify TestSlack1
`sdf`sdf`sdf`
