### PR TITLE
feat: strip details tags from Slack & Markdown. Convert Summary to heading

### DIFF
--- a/pkg/markdown/markdown.go
+++ b/pkg/markdown/markdown.go
@@ -12,6 +12,8 @@ func ConvertToSlack(markdown string) string {
 	// Remove carriage returns
 	markdown = strings.ReplaceAll(markdown, "\r\n", "\n")
 
+	markdown = stripDetailsTags(markdown)
+
 	var regex *regexp.Regexp
 	// Convert bullets (* -> •)
 	regex = regexp.MustCompile(`(^|\n)(|\s+)\*\s`)
@@ -70,6 +72,8 @@ func ConvertToSlack(markdown string) string {
 
 // ConvertToHTML converts the Markdown syntax into HTML and sanitises the result.
 func ConvertToHTML(markdown string) string {
+	markdown = stripDetailsTags(markdown)
+
 	mdParser := md.New(md.HTML(true), md.Breaks(true))
 	unsafeHTML := mdParser.RenderToString([]byte(markdown))
 	safeHTML := bluemonday.UGCPolicy().Sanitize(unsafeHTML)
@@ -78,4 +82,15 @@ func ConvertToHTML(markdown string) string {
 	// notifications consistent
 	regex := regexp.MustCompile(`(?miU)((<h\d>)(.+)(</h\d>))`)
 	return regex.ReplaceAllString(safeHTML, "<header>$3</header>")
+}
+
+// stripDetailsTags handles GitHub-style <details>/<summary> markup so it renders
+// cleanly: <summary>X</summary> is rewritten to a heading, and the surrounding
+// <details> tags are removed.
+func stripDetailsTags(markdown string) string {
+	summaryRegex := regexp.MustCompile(`(?i)<summary(?:\s[^>]*)?>(.*?)</summary>`)
+	markdown = summaryRegex.ReplaceAllString(markdown, "\n## $1\n")
+
+	tagRegex := regexp.MustCompile(`(?i)</?(?:details|summary)(?:\s[^>]*)?>`)
+	return tagRegex.ReplaceAllString(markdown, "")
 }

--- a/pkg/markdown/markdown_test.go
+++ b/pkg/markdown/markdown_test.go
@@ -97,6 +97,24 @@ func TestMarkdown_Converters(t *testing.T) {
 			expectedSlack: "<spring-financial-group/mqube-property-service#770|https://github.com/spring-financial-group/mqube-property-service/pull/770>",
 			expectedHTML:  "<p>spring-financial-group/mqube-property-service#770</p>\n",
 		},
+		{
+			name:          "DetailsBlockWithSummary",
+			inputMarkdown: "<details>\n<summary>Click to expand</summary>\n\nHidden content here\n\n</details>",
+			expectedSlack: "\n\n*Click to expand*\n\n\nHidden content here\n\n",
+			expectedHTML:  "<header>Click to expand</header>\n<p>Hidden content here</p>\n",
+		},
+		{
+			name:          "DetailsBlockWithOpenAttribute",
+			inputMarkdown: "<details open>\n<summary>Details</summary>\n\nMore info\n\n</details>",
+			expectedSlack: "\n\n*Details*\n\n\nMore info\n\n",
+			expectedHTML:  "<header>Details</header>\n<p>More info</p>\n",
+		},
+		{
+			name:          "DetailsBlockWithoutSummary",
+			inputMarkdown: "<details>\nJust some collapsible text\n</details>",
+			expectedSlack: "\nJust some collapsible text\n",
+			expectedHTML:  "<p>Just some collapsible text</p>\n",
+		},
 	}
 
 	for _, tt := range testCases {


### PR DESCRIPTION
### Changes
* Strip `<details>` and `<summary>` from input markdown
* Convert `<summary>` to a heading

### Context
We want details drop downs in our Peacock messages so that we can shorten some of our auto generated release notes.

We don't want these drop downs to be in any emails or slack messages as they may not be supported.

Anything that is in details tags will be shown from emails or slack messages and anything in the summary tags will be shown as headings.
