### PR TITLE
feat: support Gateway API configuration

### DIFF
--- a/charts/peacock/templates/httproute.yaml
+++ b/charts/peacock/templates/httproute.yaml
@@ -1,0 +1,49 @@
+{{- if and (eq .Values.routeKind "httproute") (.Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) }}
+{{- $annotations := dict }}
+{{- $_ := merge $annotations .Values.gateway.annotations .Values.jxRequirements.ingress.annotations }}
+{{- $isNodePort := and (hasKey .Values.jxRequirements.ingress "serviceType") (.Values.jxRequirements.ingress.serviceType) (eq .Values.jxRequirements.ingress.serviceType "NodePort") }}
+{{- if and $isNodePort (not (hasKey $annotations "jenkins.io/host")) }}
+{{- $_ := set $annotations "jenkins.io/host" .Values.jxRequirements.ingress.domain }}
+{{- end }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  annotations:
+{{- if $annotations }}
+{{ toYaml $annotations | indent 4 }}
+{{- end }}
+  name: {{ .Values.service.name }}
+{{- if .Values.gateway.labels }}
+{{ toYaml .Values.gateway.labels | indent 4 }}
+{{- end }}
+spec:
+  parentRefs:
+  - name: {{ required "gateway.name is required when routeKind is httproute" .Values.gateway.name }}
+    namespace: {{ required "gateway.namespace is required when routeKind is httproute" .Values.gateway.namespace }}
+    sectionName: https
+{{- if not .Values.jxRequirements.ingress.tls.enabled }}
+  - name: {{ .Values.gateway.name }}
+    namespace: {{ .Values.gateway.namespace }}
+    sectionName: http
+{{- end }}
+{{- if not $isNodePort }}
+  hostnames:
+{{- if .Values.preview }}
+  - {{ trimAll "jx-spring-financial-group-" .Values.jxRequirements.ingress.namespaceSubDomain }}{{ .Values.jxRequirements.ingress.domain }}
+{{- else }}
+  - {{ .Values.service.name }}{{ .Values.jxRequirements.ingress.namespaceSubDomain }}{{ .Values.jxRequirements.ingress.domain }}
+{{- end }}
+{{- end }}
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+{{- if $isNodePort }}
+        value: "/{{ .Release.Namespace }}/hook"
+{{- else }}
+        value: {{ .Values.gateway.httpRoute.pathPrefix }}
+{{- end }}
+    backendRefs:
+    - name: {{ .Values.service.name }}
+      port: {{ .Values.service.externalPort }}
+{{- end }}

--- a/charts/peacock/templates/ingress.yaml
+++ b/charts/peacock/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.jxRequirements.ingress.domain }}
+{{- if and (eq (.Values.routeKind | default "ingress") "ingress") (.Values.jxRequirements.ingress.domain) }}
 {{- $annotations := dict }}
 {{- $_ := merge $annotations .Values.ingress.annotations .Values.jxRequirements.ingress.annotations  }}
 {{- if not (hasKey $annotations "kubernetes.io/ingress.class") }}

--- a/charts/peacock/values.yaml
+++ b/charts/peacock/values.yaml
@@ -104,6 +104,8 @@ readinessProbe:
   # Optional distinct readiness probe path, if empty the probePath is used
   probePath: ""
 
+routeKind: ingress # options: ingress, httproute
+
 # custom ingress annotations on this service
 ingress:
   annotations: {}
@@ -114,6 +116,18 @@ ingress:
 
   # ingress path type
   pathType: ImplementationSpecific
+
+# custom HTTPRoute configuration on this service
+# enable by setting routeKind: httproute
+gateway:
+  # Gateway to attach the HTTPRoute to
+  name: ""
+  # Namespace of the Gateway, defaults to the same namespace as the service
+  namespace: ""
+  httpRoute:
+    pathPrefix: /
+  annotations: {}
+  labels: {}
 
 serviceAccount:
   enabled: true

--- a/preview/values.yaml.gotmpl
+++ b/preview/values.yaml.gotmpl
@@ -2,6 +2,12 @@ jxRequirements:
   ingress:
     namespaceSubDomain: "-pr{{ requiredEnv "PULL_NUMBER" }}."
 
+routeKind: httproute
+
+gateway:
+  name: envoy-gateway
+  namespace: envoy-gateway-system
+
 image:
   repository: "{{ requiredEnv "DOCKER_REGISTRY" }}/{{ requiredEnv "DOCKER_REGISTRY_ORG" }}/{{ requiredEnv "APP_NAME" }}"
   tag: "{{ requiredEnv "VERSION" }}"


### PR DESCRIPTION
### Changes
* Add HTTPRoute template and `gateway` block to values for configuration
* Add `routeKind` block to values for switching between `ingress` and `httproute` options
* Deploy HTTPRoute in preview with envoy-gateway as the Gateway provider
