### PR TITLE
fix: clean up newlines around the details tags

### DIFF
--- a/pkg/markdown/markdown.go
+++ b/pkg/markdown/markdown.go
@@ -1,10 +1,11 @@
 package markdown
 
 import (
-	"github.com/microcosm-cc/bluemonday"
-	md "gitlab.com/golang-commonmark/markdown"
 	"regexp"
 	"strings"
+
+	"github.com/microcosm-cc/bluemonday"
+	md "gitlab.com/golang-commonmark/markdown"
 )
 
 // ConvertToSlack converts the basic Markdown syntax into Slack Markup.
@@ -87,10 +88,15 @@ func ConvertToHTML(markdown string) string {
 // stripDetailsTags handles GitHub-style <details>/<summary> markup so it renders
 // cleanly: <summary>X</summary> is rewritten to a heading, and the surrounding
 // <details> tags are removed.
+// Each tag also consumes its adjacent newline so the
+// blank lines that wrapped the original markup don't pile up in the output.
 func stripDetailsTags(markdown string) string {
-	summaryRegex := regexp.MustCompile(`(?i)<summary(?:\s[^>]*)?>(.*?)</summary>`)
-	markdown = summaryRegex.ReplaceAllString(markdown, "\n## $1\n")
+	summaryRegex := regexp.MustCompile(`(?i)<summary(?:\s[^>]*)?>(.*?)</summary>\n?`)
+	markdown = summaryRegex.ReplaceAllString(markdown, "## $1\n")
 
-	tagRegex := regexp.MustCompile(`(?i)</?(?:details|summary)(?:\s[^>]*)?>`)
-	return tagRegex.ReplaceAllString(markdown, "")
+	openRegex := regexp.MustCompile(`(?i)<details(?:\s[^>]*)?>\n?`)
+	markdown = openRegex.ReplaceAllString(markdown, "")
+
+	closeRegex := regexp.MustCompile(`(?i)\n?</details>`)
+	return closeRegex.ReplaceAllString(markdown, "")
 }

--- a/pkg/markdown/markdown_test.go
+++ b/pkg/markdown/markdown_test.go
@@ -1,9 +1,10 @@
 package markdown_test
 
 import (
+	"testing"
+
 	"github.com/spring-financial-group/peacock/pkg/markdown"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestMarkdown_Converters(t *testing.T) {
@@ -100,20 +101,26 @@ func TestMarkdown_Converters(t *testing.T) {
 		{
 			name:          "DetailsBlockWithSummary",
 			inputMarkdown: "<details>\n<summary>Click to expand</summary>\n\nHidden content here\n\n</details>",
-			expectedSlack: "\n\n*Click to expand*\n\n\nHidden content here\n\n",
+			expectedSlack: "*Click to expand*\n\nHidden content here\n",
 			expectedHTML:  "<header>Click to expand</header>\n<p>Hidden content here</p>\n",
 		},
 		{
 			name:          "DetailsBlockWithOpenAttribute",
 			inputMarkdown: "<details open>\n<summary>Details</summary>\n\nMore info\n\n</details>",
-			expectedSlack: "\n\n*Details*\n\n\nMore info\n\n",
+			expectedSlack: "*Details*\n\nMore info\n",
 			expectedHTML:  "<header>Details</header>\n<p>More info</p>\n",
 		},
 		{
 			name:          "DetailsBlockWithoutSummary",
 			inputMarkdown: "<details>\nJust some collapsible text\n</details>",
-			expectedSlack: "\nJust some collapsible text\n",
+			expectedSlack: "Just some collapsible text",
 			expectedHTML:  "<p>Just some collapsible text</p>\n",
+		},
+		{
+			name:          "DetailsBlockCollapsesSurroundingBlankLines",
+			inputMarkdown: "<details open>\n<summary>Some Important Summary</summary>\n\n### Important Header\n**A Service**\n- A feature\n\n</details>",
+			expectedSlack: "*Some Important Summary*\n\n*Important Header*\n*A Service*\n• A feature\n",
+			expectedHTML:  "<header>Some Important Summary</header>\n<header>Important Header</header>\n<p><strong>A Service</strong></p>\n<ul>\n<li>A feature</li>\n</ul>\n",
 		},
 	}
 


### PR DESCRIPTION
### Changes
* Clean up newlines around details tags

### Context
Seeing lots of newlines being outputted in the markdown when details tags are used.
