### PR TITLE
fix: aggressively consume newlines that are only required due to commonmark

### DIFF
--- a/pkg/markdown/markdown.go
+++ b/pkg/markdown/markdown.go
@@ -87,17 +87,18 @@ func ConvertToHTML(markdown string) string {
 
 // stripDetailsTags handles GitHub-style <details>/<summary> markup so it renders
 // cleanly: <summary>X</summary> is rewritten to a heading, and the surrounding
-// <details> tags are removed. Each tag also consumes all adjacent newlines —
-// GitHub requires blank lines around the inner content for it to be parsed as
-// markdown rather than raw HTML, and once we've stripped the tags ourselves
-// those blank lines are just noise.
+// <details> tags are removed.
+// Each tag also consumes up to one adjacent blank line on its inner side
+// (after the opening/summary tags, before the closing tag) so the blank line
+// GitHub requires for the inner content to parse as markdown doesn't leak
+// into the output. Any further blank lines the author added are preserved.
 func stripDetailsTags(markdown string) string {
-	summaryRegex := regexp.MustCompile(`(?i)<summary(?:\s[^>]*)?>(.*?)</summary>\n*`)
+	summaryRegex := regexp.MustCompile(`(?i)<summary(?:\s[^>]*)?>(.*?)</summary>\n{0,2}`)
 	markdown = summaryRegex.ReplaceAllString(markdown, "## $1\n")
 
-	openRegex := regexp.MustCompile(`(?i)<details(?:\s[^>]*)?>\n*`)
+	openRegex := regexp.MustCompile(`(?i)<details(?:\s[^>]*)?>\n{0,2}`)
 	markdown = openRegex.ReplaceAllString(markdown, "")
 
-	closeRegex := regexp.MustCompile(`(?i)\n*</details>`)
+	closeRegex := regexp.MustCompile(`(?i)\n{0,2}</details>`)
 	return closeRegex.ReplaceAllString(markdown, "")
 }

--- a/pkg/markdown/markdown.go
+++ b/pkg/markdown/markdown.go
@@ -87,16 +87,17 @@ func ConvertToHTML(markdown string) string {
 
 // stripDetailsTags handles GitHub-style <details>/<summary> markup so it renders
 // cleanly: <summary>X</summary> is rewritten to a heading, and the surrounding
-// <details> tags are removed.
-// Each tag also consumes its adjacent newline so the
-// blank lines that wrapped the original markup don't pile up in the output.
+// <details> tags are removed. Each tag also consumes all adjacent newlines —
+// GitHub requires blank lines around the inner content for it to be parsed as
+// markdown rather than raw HTML, and once we've stripped the tags ourselves
+// those blank lines are just noise.
 func stripDetailsTags(markdown string) string {
-	summaryRegex := regexp.MustCompile(`(?i)<summary(?:\s[^>]*)?>(.*?)</summary>\n?`)
+	summaryRegex := regexp.MustCompile(`(?i)<summary(?:\s[^>]*)?>(.*?)</summary>\n*`)
 	markdown = summaryRegex.ReplaceAllString(markdown, "## $1\n")
 
-	openRegex := regexp.MustCompile(`(?i)<details(?:\s[^>]*)?>\n?`)
+	openRegex := regexp.MustCompile(`(?i)<details(?:\s[^>]*)?>\n*`)
 	markdown = openRegex.ReplaceAllString(markdown, "")
 
-	closeRegex := regexp.MustCompile(`(?i)\n?</details>`)
+	closeRegex := regexp.MustCompile(`(?i)\n*</details>`)
 	return closeRegex.ReplaceAllString(markdown, "")
 }

--- a/pkg/markdown/markdown_test.go
+++ b/pkg/markdown/markdown_test.go
@@ -122,6 +122,12 @@ func TestMarkdown_Converters(t *testing.T) {
 			expectedSlack: "*Some Important Summary*\n*Important Header*\n*A Service*\n• A feature",
 			expectedHTML:  "<header>Some Important Summary</header>\n<header>Important Header</header>\n<p><strong>A Service</strong></p>\n<ul>\n<li>A feature</li>\n</ul>\n",
 		},
+		{
+			name:          "DetailsBlockPreservesIntentionalBlankLines",
+			inputMarkdown: "<details>\n<summary>Title</summary>\n\n\nFirst paragraph\n\n\n</details>",
+			expectedSlack: "*Title*\n\nFirst paragraph\n",
+			expectedHTML:  "<header>Title</header>\n<p>First paragraph</p>\n",
+		},
 	}
 
 	for _, tt := range testCases {

--- a/pkg/markdown/markdown_test.go
+++ b/pkg/markdown/markdown_test.go
@@ -101,13 +101,13 @@ func TestMarkdown_Converters(t *testing.T) {
 		{
 			name:          "DetailsBlockWithSummary",
 			inputMarkdown: "<details>\n<summary>Click to expand</summary>\n\nHidden content here\n\n</details>",
-			expectedSlack: "*Click to expand*\n\nHidden content here\n",
+			expectedSlack: "*Click to expand*\nHidden content here",
 			expectedHTML:  "<header>Click to expand</header>\n<p>Hidden content here</p>\n",
 		},
 		{
 			name:          "DetailsBlockWithOpenAttribute",
 			inputMarkdown: "<details open>\n<summary>Details</summary>\n\nMore info\n\n</details>",
-			expectedSlack: "*Details*\n\nMore info\n",
+			expectedSlack: "*Details*\nMore info",
 			expectedHTML:  "<header>Details</header>\n<p>More info</p>\n",
 		},
 		{
@@ -119,7 +119,7 @@ func TestMarkdown_Converters(t *testing.T) {
 		{
 			name:          "DetailsBlockCollapsesSurroundingBlankLines",
 			inputMarkdown: "<details open>\n<summary>Some Important Summary</summary>\n\n### Important Header\n**A Service**\n- A feature\n\n</details>",
-			expectedSlack: "*Some Important Summary*\n\n*Important Header*\n*A Service*\n• A feature\n",
+			expectedSlack: "*Some Important Summary*\n*Important Header*\n*A Service*\n• A feature",
 			expectedHTML:  "<header>Some Important Summary</header>\n<header>Important Header</header>\n<p><strong>A Service</strong></p>\n<ul>\n<li>A feature</li>\n</ul>\n",
 		},
 	}


### PR DESCRIPTION
### Changes
* More aggressively consume adjacent newlines to html tags

### Context
Still seeing rogue newlines being outputted in Peacock messages.

Github requires additional newlines to correctly parse HTML in their PR descriptions. Every tag now eats the GitHub-mandated newline that sits next to it, on top of the trailing/leading newline that the `stripDetailsTags()` was already consuming.

Any additional newlines added after the Github mandated newline is preserved meaning that if the author really wants a newline they just need to add another additional newline.
