### PR TITLE
feat: make actual note vs template note equality more strict

### DIFF
--- a/pkg/webhook/usecase/webhookuc.go
+++ b/pkg/webhook/usecase/webhookuc.go
@@ -81,12 +81,8 @@ func (w *WebHookUseCase) ValidatePeacock(e *models.PullRequestEventDTO) error {
 		return w.handleError(ctx, domain.ValidationContext, e, err)
 	}
 
-	areSame, err := w.compareReleaseNotesAndTemplate(releaseNotes, templateReleaseNotes)
-	if err != nil {
-		return w.handleError(ctx, domain.ValidationContext, e, err)
-	}
-
-	if areSame {
+	areEqual := w.areActualNotesAndTemplatesEqual(releaseNotes, templateReleaseNotes)
+	if areEqual {
 		log.Infof("release notes are same as the pull request template, failing")
 		return w.handleError(ctx, domain.ValidationContext, e, errors.New("release notes cannot be the same as the pull request template"))
 	}
@@ -299,85 +295,17 @@ func (w *WebHookUseCase) getChangedEnv(files []*github.CommitFile) string {
 	return ""
 }
 
-func (w *WebHookUseCase) compareReleaseNotesAndTemplate(
-	notes []models.ReleaseNote,
-	templates []models.ReleaseNote,
-) (bool, error) {
-
-	if len(notes) != len(templates) {
-		return false, nil
-	}
-
-	// Index templates by content (or another stable key if you have one)
-	templateIndex := make(map[string]models.ReleaseNote, len(templates))
+func (w *WebHookUseCase) areActualNotesAndTemplatesEqual(notes, templates []models.ReleaseNote) bool {
+	templateIndex := make(map[string]struct{}, len(templates))
 	for _, t := range templates {
-		templateIndex[t.Content] = t
+		templateIndex[t.Content] = struct{}{}
 	}
 
 	for _, note := range notes {
-		tmpl, ok := templateIndex[note.Content]
-		if !ok {
-			return false, nil
-		}
-
-		if !teamsEqual(note.Teams, tmpl.Teams) {
-			return false, nil
+		_, ok := templateIndex[note.Content]
+		if ok {
+			return true
 		}
 	}
-
-	return true, nil
-}
-
-func teamsEqual(a, b models.Teams) bool {
-	if len(a) != len(b) {
-		return false
-	}
-
-	index := make(map[string]models.Team, len(a))
-	for _, team := range a {
-		index[team.Name] = team
-	}
-
-	for _, team := range b {
-		existing, ok := index[team.Name]
-		if !ok {
-			return false
-		}
-
-		if !teamEqual(existing, team) {
-			return false
-		}
-	}
-
-	return true
-}
-
-func teamEqual(a, b models.Team) bool {
-	if a.Name != b.Name ||
-		a.APIKey != b.APIKey ||
-		a.ContactType != b.ContactType {
-		return false
-	}
-
-	return stringSliceEqual(a.Addresses, b.Addresses)
-}
-
-func stringSliceEqual(a, b []string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-
-	m := make(map[string]int, len(a))
-	for _, v := range a {
-		m[v]++
-	}
-
-	for _, v := range b {
-		if m[v] == 0 {
-			return false
-		}
-		m[v]--
-	}
-
-	return true
+	return false
 }

--- a/pkg/webhook/usecase/webhookuc.go
+++ b/pkg/webhook/usecase/webhookuc.go
@@ -295,6 +295,8 @@ func (w *WebHookUseCase) getChangedEnv(files []*github.CommitFile) string {
 	return ""
 }
 
+// areActualNotesAndTemplatesEqual checks whether any of the actual notes have the same content as the templates.
+// This is to prevent the repo template messages from accidentally being sent to teams.
 func (w *WebHookUseCase) areActualNotesAndTemplatesEqual(notes, templates []models.ReleaseNote) bool {
 	templateIndex := make(map[string]struct{}, len(templates))
 	for _, t := range templates {

--- a/pkg/webhook/usecase/webhookuc_test.go
+++ b/pkg/webhook/usecase/webhookuc_test.go
@@ -295,67 +295,88 @@ func TestWebHookUseCase_getPRTemplate(t *testing.T) {
 }
 
 func TestWebHookUseCase_compareReleaseNotesAndTemplate(t *testing.T) {
-	mockSCM := mocks.NewSCM(t)
-	mockNotesUC := mocks.NewReleaseNotesUseCase(t)
-	mockReleaseUC := mocks.NewReleaseUseCase(t)
-
-	cfg := &config.SCM{
-		User: RepoOwner,
-	}
-
-	uc := NewUseCase(cfg, mockSCM, mockNotesUC, feathers.NewUseCase(), mockReleaseUC)
-
-	notes1 := []models.ReleaseNote{
+	testCases := []struct {
+		name          string
+		a             []models.ReleaseNote
+		b             []models.ReleaseNote
+		expectedEqual bool
+	}{
 		{
-			Teams:   models.Teams{infraTeam},
-			Content: "First note",
-		},
-		{
-			Teams:   models.Teams{productTeam},
-			Content: "Second note",
-		},
-	}
-
-	notes2 := []models.ReleaseNote{
-		{
-			Teams:   models.Teams{infraTeam},
-			Content: "First note",
-		},
-		{
-			Teams:   models.Teams{productTeam},
-			Content: "Second note",
-		},
-	}
-
-	t.Run("should return false when lengths are different", func(t *testing.T) {
-		notesShort := []models.ReleaseNote{
-			{
-				Teams:   models.Teams{infraTeam},
-				Content: "First note",
+			name: "Equal if both contents are the same",
+			a: []models.ReleaseNote{
+				{
+					Content: "Template message for infra",
+				},
 			},
-		}
+			b: []models.ReleaseNote{
+				{
+					Content: "Template message for infra",
+				},
+			},
+			expectedEqual: true,
+		},
+		{
+			name: "Not equal if different contents",
+			a: []models.ReleaseNote{
+				{
+					Content: "Template message for infra",
+				},
+			},
+			b: []models.ReleaseNote{
+				{
+					Content: "Actual message for infra",
+				},
+			},
+			expectedEqual: false,
+		},
+		{
+			name: "Equal if at least one content is the same",
+			a: []models.ReleaseNote{
+				{
+					Content: "Template message for infra",
+				},
+			},
+			b: []models.ReleaseNote{
+				{
+					Content: "Actual message for infra",
+				},
+				{
+					Content: "Template message for infra",
+				},
+			},
+			expectedEqual: true,
+		},
+		{
+			name: "Equal if different teams with same content",
+			a: []models.ReleaseNote{
+				{
+					Teams:   models.Teams{infraTeam},
+					Content: "Template message for infra",
+				},
+			},
+			b: []models.ReleaseNote{
+				{
+					Teams:   models.Teams{productTeam},
+					Content: "Template message for infra",
+				},
+			},
+			expectedEqual: true,
+		},
+	}
 
-		areSame, err := uc.compareReleaseNotesAndTemplate(notes1, notesShort)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockSCM := mocks.NewSCM(t)
+			mockNotesUC := mocks.NewReleaseNotesUseCase(t)
+			mockReleaseUC := mocks.NewReleaseUseCase(t)
 
-		assert.NoError(t, err)
-		assert.False(t, areSame)
-	})
+			cfg := &config.SCM{
+				User: RepoOwner,
+			}
 
-	t.Run("should return true when lengths are equal (TODO: incomplete implementation)", func(t *testing.T) {
-		areSame, err := uc.compareReleaseNotesAndTemplate(notes1, notes2)
-
-		assert.NoError(t, err)
-		// Note: This returns true due to incomplete implementation (TODO in the code)
-		assert.True(t, areSame)
-	})
-
-	t.Run("should return true for empty slices", func(t *testing.T) {
-		emptyNotes1 := []models.ReleaseNote{}
-		emptyNotes2 := []models.ReleaseNote{}
-
-		areSame, err := uc.compareReleaseNotesAndTemplate(emptyNotes1, emptyNotes2)
-
-		assert.NoError(t, err)
-		assert.True(t, areSame)
-	})
+			uc := NewUseCase(cfg, mockSCM, mockNotesUC, feathers.NewUseCase(), mockReleaseUC)
+			actualEqual := uc.areActualNotesAndTemplatesEqual(tc.a, tc.b)
+			assert.Equal(t, tc.expectedEqual, actualEqual)
+		})
+	}
 }


### PR DESCRIPTION
### Changes
* Make note equality more strict
* Remove teams comparison

### Context
Previously we were exiting early if any actual note was different from a template. I don't think this should be the behaviour, we want to make sure that none of the notes are equal to the template.

We were also comparing the teams in the template vs actual notes. I think this is a redundant check, we don't really care about the teams that are in the templates we just want to make sure the contents are different. It's possible that someone could edit the teams but forget to edit the note's contents.

The new flow is to check that none of the actual release notes equal any of the template release notes.
