### PR TITLE
perf: configure athens-proxy for pipelines with GOPROXY

### DIFF
--- a/.lighthouse/jenkins-x/golint.yaml
+++ b/.lighthouse/jenkins-x/golint.yaml
@@ -10,6 +10,10 @@ spec:
         resources: {}
         taskSpec:
           metadata: {}
+          stepTemplate:
+            env:
+              - name: GOPROXY
+                value: "http://athens-proxy.infrastructure.svc.cluster.local,direct"
           steps:
             - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone-pr.yaml@versionStream
               name: ""

--- a/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/.lighthouse/jenkins-x/pullrequest.yaml
@@ -23,6 +23,8 @@ spec:
             value: ./docs/swagger.json
           - name: OutputLanguages
             value: csharp angular
+          - name: GOPROXY
+            value: "http://athens-proxy.infrastructure.svc.cluster.local,direct"
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone-pr.yaml@versionStream
           name: ""

--- a/.lighthouse/jenkins-x/release.yaml
+++ b/.lighthouse/jenkins-x/release.yaml
@@ -24,6 +24,8 @@ spec:
             value: ./docs/swagger.json
           - name: OutputLanguages
             value: csharp angular
+          - name: GOPROXY
+            value: "http://athens-proxy.infrastructure.svc.cluster.local,direct"
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone.yaml@versionStream
           name: ""

--- a/.lighthouse/jenkins-x/tests.yaml
+++ b/.lighthouse/jenkins-x/tests.yaml
@@ -16,6 +16,9 @@ spec:
             resources:
               limits: {}
             workingDir: /workspace/source
+            env:
+              - name: GOPROXY
+                value: "http://athens-proxy.infrastructure.svc.cluster.local,direct"
           steps:
             - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone-pr.yaml@versionStream
               name: ""


### PR DESCRIPTION
### Changes
* Set `GOPROXY="http://athens-proxy.infrastructure.svc.cluster.local,direct"` as env var in pipelines

### Context

Define `GOPROXY` to set module proxy behaviour:

1. Try fetching remote modules from `athens-proxy` in the `infrastructure` namespace
2. For each failure, fetch module directly from source

This saves around 10s-20s per pipeline run, and reduces traffic in and out of the cluster for cost savings